### PR TITLE
Add filtering option for active/archived PET listing API endpoints, add linked tasks to protocol serializer [SCI-7091]

### DIFF
--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -9,6 +9,8 @@ module Api
 
       class IncludeNotSupportedError < StandardError; end
 
+      class FilterParamError < StandardError; end
+
       class PermissionError < StandardError
         attr_reader :klass, :mode
 
@@ -23,6 +25,14 @@ module Api
         logger.error e.backtrace.join("\n")
         render_error(I18n.t('api.core.errors.general.title'),
                      I18n.t('api.core.errors.general.detail'),
+                     :bad_request)
+      end
+
+      rescue_from FilterParamError do |e|
+        logger.error e.message
+        logger.error e.backtrace.join("\n")
+        render_error(I18n.t('api.core.errors.filter_parameter.title'),
+                     I18n.t('api.core.errors.filter_parameter.detail'),
                      :bad_request)
       end
 
@@ -220,6 +230,19 @@ module Api
 
       def load_workflow(key = :workflow_id)
         @workflow = MyModuleStatusFlow.find(params.require(key))
+      end
+
+      def archived_filter(archivable_collection)
+        return archivable_collection if params.dig(:filter, :archived).blank?
+
+        case params.dig(:filter, :archived)
+        when 'false'
+          archivable_collection.active
+        when 'true'
+          archivable_collection.archived
+        else
+          raise FilterParamError
+        end
       end
     end
   end

--- a/app/controllers/api/v1/experiments_controller.rb
+++ b/app/controllers/api/v1/experiments_controller.rb
@@ -11,9 +11,8 @@ module Api
       before_action :load_experiment_for_managing, only: %i(update)
 
       def index
-        experiments = @project.experiments
-                              .page(params.dig(:page, :number))
-                              .per(params.dig(:page, :size))
+        experiments = archived_filter(@project.experiments).page(params.dig(:page, :number))
+                                                           .per(params.dig(:page, :size))
         render jsonapi: experiments, each_serializer: ExperimentSerializer
       end
 

--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -11,10 +11,9 @@ module Api
       before_action :load_project_for_managing, only: %i(update)
 
       def index
-        projects = @team.projects
-                        .visible_to(current_user, @team)
-                        .page(params.dig(:page, :number))
-                        .per(params.dig(:page, :size))
+        projects = @team.projects.visible_to(current_user, @team)
+        projects = archived_filter(projects).page(params.dig(:page, :number))
+                                            .per(params.dig(:page, :size))
 
         render jsonapi: projects, each_serializer: ProjectSerializer, include: include_params
       end

--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -15,10 +15,9 @@ module Api
       before_action :load_task, only: :activities
 
       def index
-        tasks = @experiment.my_modules
-                           .includes(:my_module_status, :my_modules, :my_module_antecessors)
-                           .page(params.dig(:page, :number))
-                           .per(params.dig(:page, :size))
+        tasks = @experiment.my_modules.includes(:my_module_status, :my_modules, :my_module_antecessors)
+        tasks = archived_filter(tasks).page(params.dig(:page, :number))
+                                      .per(params.dig(:page, :size))
 
         render jsonapi: tasks, each_serializer: TaskSerializer,
                                include: include_params,

--- a/app/models/protocol.rb
+++ b/app/models/protocol.rb
@@ -149,7 +149,12 @@ class Protocol < ApplicationRecord
   has_many :published_versions,
            -> { in_repository_published_version },
            class_name: 'Protocol',
-           foreign_key: 'parent_id'
+           foreign_key: 'parent_id',
+           inverse_of: :parent,
+           dependent: :destroy
+  has_many :linked_my_modules,
+           through: :linked_children,
+           source: :my_module
   has_many :protocol_protocol_keywords,
            inverse_of: :protocol,
            dependent: :destroy

--- a/app/serializers/api/v1/protocol_serializer.rb
+++ b/app/serializers/api/v1/protocol_serializer.rb
@@ -16,6 +16,11 @@ module Api
                unless: -> { object.protocol_keywords.blank? }
       has_many :steps, serializer: StepSerializer, if: -> { object.steps.any? }
       belongs_to :parent, serializer: ProtocolSerializer, if: -> { object.parent.present? }
+      has_many :linked_my_modules,
+               key: :linked_tasks,
+               serializer: TaskSerializer,
+               class_name: 'MyModule',
+               if: -> { object.in_repository_published? }
 
       include TimestampableModel
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3504,6 +3504,9 @@ en:
         general:
           title: "Error"
           detail: "Something went wrong, please contact resource owner"
+        filter_parameter:
+          title: "Filter parameter error"
+          detail: "Filter parameter contains incorrect value"
         parameter:
           title: "Missing parameter"
         parameter_incorrect:


### PR DESCRIPTION
Jira ticket: [SCI-7091](https://biosistemika.atlassian.net/browse/SCI-7091)

### What was done
Add filtering option for active/archived PET listing API endpoints, add linked tasks to protocol serializer

[SCI-7091]: https://scinote.atlassian.net/browse/SCI-7091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ