### PR TITLE
Improve speed of group unassignment job as it is executed in foreground [SCI-7180]

### DIFF
--- a/app/jobs/user_assignments/group_assignment_job.rb
+++ b/app/jobs/user_assignments/group_assignment_job.rb
@@ -9,7 +9,7 @@ module UserAssignments
       @assigned_by = assigned_by
 
       ActiveRecord::Base.transaction do
-        team.users.where.not(id: assigned_by.id).find_each do |user|
+        team.users.where.not(id: assigned_by).find_each do |user|
           user_assignment = UserAssignment.find_or_initialize_by(
             user: user,
             assignable: project

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -326,7 +326,7 @@ class Project < ApplicationRecord
     UserAssignments::GroupAssignmentJob.perform_now(
       team,
       self,
-      created_by
+      last_modified_by || created_by
     )
   end
 


### PR DESCRIPTION
Jira ticket: [SCI-7180](https://biosistemika.atlassian.net/browse/SCI-7180)

### What was done
Improve speed of group unassignment job as it is executed in foreground