### PR TITLE
Escape underscores when sending ZPL to render service [SCI-7223]

### DIFF
--- a/app/services/label_templates_preview_service.rb
+++ b/app/services/label_templates_preview_service.rb
@@ -17,7 +17,7 @@ class LabelTemplatesPreviewService
       invocation_type: 'RequestResponse',
       log_type: 'Tail',
       payload:
-        "{ \"content\": #{@params[:zpl].to_json},"\
+        "{ \"content\": #{sanitize_zpl_code(@params[:zpl]).to_json},"\
         "\"width\": #{@params[:width]},"\
         "\"height\": #{@params[:height]},"\
         "\"density\": #{@params[:density]} "\
@@ -29,5 +29,11 @@ class LabelTemplatesPreviewService
     else
       @error = resp.function_error.string
     end
+  end
+
+  private
+
+  def sanitize_zpl_code(zpl_code)
+    zpl_code.gsub!('_', '_5F')
   end
 end


### PR DESCRIPTION
Jira ticket: [SCI-7223](https://biosistemika.atlassian.net/browse/SCI-7223)

### What was done
Escape underscores when sending ZPL to render service