### PR TITLE
Incorrect translation on the 'Edit Workflow' button in experiment canvas [SCI-7679]

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1393,7 +1393,7 @@ en:
       actions: 'Experiment'
       view: 'View'
       head_title: "%{project} | Overview"
-      canvas_edit: "Edit workflow"
+      canvas_edit: "Edit Workflow"
       canvas_empty: "It's empty here. Please add some tasks"
       new_my_module: "New task"
       new_my_module_modal:
@@ -1408,7 +1408,6 @@ en:
         tags: "Add tags (optional)"
         create: "Create"
         enter_placeholder: 'Enter...'
-      canvas_edit: "Edit Experiment"
       zoom: "Zoom: "
       reload_on_submit: "Save action is running. Reloading this page may cause unexpected behavior."
       modal_manage_tags:


### PR DESCRIPTION
Jira ticket: [SCI-7679](https://scinote.atlassian.net/browse/SCI-7679)

### What was done
_changed button name for editing canvas_

### Note:
_due_first_html and due_last_html translations dont exist?_


[SCI-7679]: https://scinote.atlassian.net/browse/SCI-7679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ