### PR TITLE
Refresh canvas navigator image after moving tasks [SCI-7661]

### DIFF
--- a/app/controllers/experiments_controller.rb
+++ b/app/controllers/experiments_controller.rb
@@ -333,6 +333,8 @@ class ExperimentsController < ApplicationController
         modules_to_move[id] = dst_experiment.id
       end
       @experiment.move_modules(modules_to_move, current_user)
+      @experiment.workflowimg.purge
+
       render json: { message: t('experiments.table.modal_move_modules.success_flash',
                                 experiment: sanitize_input(dst_experiment.name)) }
     rescue StandardError => e


### PR DESCRIPTION
Jira ticket: [SCI-7661](https://scinote.atlassian.net/browse/SCI-7661)

### What was done
Refresh canvas navigator image after moving tasks

[SCI-7661]: https://scinote.atlassian.net/browse/SCI-7661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ