### PR TITLE
Change icon for Due first to stay consistant with the global style [SCI-7705]

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3276,7 +3276,7 @@ en:
       archived_old_html: "<i class=\"fas fa-sort-numeric-down\"></i>&nbsp;&nbsp;Archived first"
       id_asc_html: "<i class=\"fas fa-sort-numeric-down\"></i>&nbsp;&nbsp;ID ascending"
       id_desc_html: "<i class=\"fas fa-sort-numeric-down-alt\"></i>&nbsp;&nbsp;ID descending"
-      due_first_html: "<i class=\"fas fa-sort-numeric-up\"></i>&nbsp;&nbsp;Due first"
+      due_first_html: "<i class=\"fas fa-sort-numeric-down\"></i>&nbsp;&nbsp;Due first"
       due_last_html: "<i class=\"fas fa-sort-numeric-down-alt\"></i>&nbsp;&nbsp;Due last"
     sort_new:
       new: "Added last"


### PR DESCRIPTION
Jira ticket: [SCI-7705](https://scinote.atlassian.net/browse/SCI-7705)

### What was done
Changed the `Due first` to `fa-sort-numeric-down`: the arrow is always pointing down.


[SCI-7705]: https://scinote.atlassian.net/browse/SCI-7705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ