### PR TITLE
Remove double tooltip on task with cloning in progress [SCI-7762]

### DIFF
--- a/app/assets/javascripts/experiments/table.js
+++ b/app/assets/javascripts/experiments/table.js
@@ -620,7 +620,7 @@ var ExperimnetTable = {
 ExperimnetTable.render.task_name = function(data) {
   let tooltip = ` title="${data.name}" data-toggle="tooltip" data-placement="bottom"`;
   if (data.provisioning_status === 'in_progress') {
-    return `<span data-full-name="${data.name}" ${tooltip}>${data.name}</span>`;
+    return `<span data-full-name="${data.name}">${data.name}</span>`;
   }
 
   return `<a


### PR DESCRIPTION
Jira ticket: [SCI-7762](https://scinote.atlassian.net/browse/SCI-7762)

### What was done
Remove the double tooltip on task with cloning in progress

[SCI-7762]: https://scinote.atlassian.net/browse/SCI-7762?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ