### PR TITLE
Fix: Edit task from experiment table view - Enter causes error [SCI-7745]

### DIFF
--- a/app/assets/javascripts/experiments/table.js
+++ b/app/assets/javascripts/experiments/table.js
@@ -464,7 +464,7 @@ var ExperimnetTable = {
   },
   clearRowTaskSelection: function() {
     this.selectedMyModules = [];
-    $('.select-all-checkboxes, .sci-checkbox').prop('checked', false);
+    $('.select-all-checkboxes .sci-checkbox').prop('checked', false);
     this.updateExperimentToolbar();
   },
   initNewTaskModal: function(table) {

--- a/app/assets/javascripts/experiments/table.js
+++ b/app/assets/javascripts/experiments/table.js
@@ -230,12 +230,12 @@ var ExperimnetTable = {
       return true;
     };
 
-    $('#modal-edit-module').on('click', 'button[data-action="confirm"]', handleRenameModal);
-
-    $('#modal-edit-module').find('form').submit((e) => {
-      e.preventDefault();
-      handleRenameModal();
-    });
+    $('#modal-edit-module')
+      .on('click', 'button[data-action="confirm"]', handleRenameModal)
+      .on('submit', 'form', (e) => {
+        e.preventDefault();
+        handleRenameModal();
+      });
   },
   initManageUsersDropdown: function() {
     $(this.table).on('show.bs.dropdown', '.assign-users-dropdown', (e) => {

--- a/app/assets/javascripts/experiments/table.js
+++ b/app/assets/javascripts/experiments/table.js
@@ -227,6 +227,10 @@ var ExperimnetTable = {
         }
       });
 
+      if ($(`.my-module-selector[data-my-module="${id}"]`).prop('checked')) {
+        $(`.my-module-selector[data-my-module="${id}"]`).click();
+      }
+
       return true;
     };
 

--- a/app/assets/javascripts/experiments/table.js
+++ b/app/assets/javascripts/experiments/table.js
@@ -201,8 +201,6 @@ var ExperimnetTable = {
       let id = $('#modal-edit-module').data('id');
       let newValue = $('#edit-module-name-input').val();
 
-      $(`.my-module-selector[data-my-module="${id}"]`).click();
-
       if (newValue === $(`#taskName${id}`).data('full-name')) {
         $('#modal-edit-module').modal('hide');
         return false;
@@ -227,9 +225,7 @@ var ExperimnetTable = {
         }
       });
 
-      if ($(`.my-module-selector[data-my-module="${id}"]`).prop('checked')) {
-        $(`.my-module-selector[data-my-module="${id}"]`).click();
-      }
+      this.clearRowTaskSelection();
 
       return true;
     };
@@ -468,7 +464,7 @@ var ExperimnetTable = {
   },
   clearRowTaskSelection: function() {
     this.selectedMyModules = [];
-    $('.select-all-checkboxes .sci-checkbox').prop('checked', false);
+    $('.select-all-checkboxes, .sci-checkbox').prop('checked', false);
     this.updateExperimentToolbar();
   },
   initNewTaskModal: function(table) {

--- a/app/assets/javascripts/experiments/table.js
+++ b/app/assets/javascripts/experiments/table.js
@@ -196,7 +196,8 @@ var ExperimnetTable = {
       $('#modal-edit-module').data('id', this.selectedMyModules[0]);
       $('#edit-module-name-input').val($(`#taskName${$('#modal-edit-module').data('id')}`).data('full-name'));
     });
-    $('#modal-edit-module').on('click', 'button[data-action="confirm"]', () => {
+
+    const handleRenameModal = () => {
       let id = $('#modal-edit-module').data('id');
       let newValue = $('#edit-module-name-input').val();
 
@@ -227,6 +228,13 @@ var ExperimnetTable = {
       });
 
       return true;
+    };
+
+    $('#modal-edit-module').on('click', 'button[data-action="confirm"]', handleRenameModal);
+
+    $('#modal-edit-module').find('form').submit((e) => {
+      e.preventDefault();
+      handleRenameModal();
     });
   },
   initManageUsersDropdown: function() {
@@ -488,7 +496,7 @@ var ExperimnetTable = {
       $.each(this.filters, (_i, filter) => {
         this.activeFilters[filter.name] = filter.apply($experimentFilter);
       });
-      
+
       // filters are active if they have any non-empty value
       let filtersEmpty = Object.values(this.activeFilters).every(value => /^\s+$/.test(value) || value === null || value === undefined || value && value.length === 0);
       this.filtersActive = !filtersEmpty;

--- a/app/assets/javascripts/experiments/table.js
+++ b/app/assets/javascripts/experiments/table.js
@@ -201,6 +201,8 @@ var ExperimnetTable = {
       let id = $('#modal-edit-module').data('id');
       let newValue = $('#edit-module-name-input').val();
 
+      $(`.my-module-selector[data-my-module="${id}"]`).trigger('click');
+
       if (newValue === $(`#taskName${id}`).data('full-name')) {
         $('#modal-edit-module').modal('hide');
         return false;
@@ -224,6 +226,10 @@ var ExperimnetTable = {
             .attr('data-error-text', error);
         }
       });
+
+      if ($(`.my-module-selector[data-my-module="${id}"]`).prop('checked')) {
+        $(`.my-module-selector[data-my-module="${id}"]`).trigger('click');
+      }
 
       this.clearRowTaskSelection();
 


### PR DESCRIPTION
Jira ticket: [SCI-7745](https://scinote.atlassian.net/browse/SCI-7745)

### What was done

- [x] While the edit module modal is open, pressing `Enter` no longer results in an error but exhibits a behavior similar to pressing the `Confirm` button.


[SCI-7745]: https://scinote.atlassian.net/browse/SCI-7745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ