### PR TITLE
Fix: Incorrect icons & double scrollbar displayed when resizing the window [SCI-7737]

### DIFF
--- a/app/assets/stylesheets/experiment/table.scss
+++ b/app/assets/stylesheets/experiment/table.scss
@@ -460,8 +460,7 @@
   }
 }
 
-
-@media (max-width: 1000px) { 
+@media (max-width: 1000px) {
   .toolbar-row {
     .button-text {
       display: none;

--- a/app/assets/stylesheets/experiment/table.scss
+++ b/app/assets/stylesheets/experiment/table.scss
@@ -459,3 +459,12 @@
     }
   }
 }
+
+
+@media (max-width: 1000px) { 
+  .toolbar-row {
+    .button-text {
+      display: none;
+    }
+  }
+}

--- a/app/views/experiments/_table_toolbar.html.erb
+++ b/app/views/experiments/_table_toolbar.html.erb
@@ -12,31 +12,31 @@
     <% end %>
     <button id="editTask" class="btn btn-light single-object-action hidden only-active" data-for="editable" >
       <i class="fas fa-pen"></i>
-      <%= t("experiments.table.toolbar.edit") %>
+      <span class="button-text"><%= t("experiments.table.toolbar.edit") %></span>  
     </button>
     <% if can_manage_experiment?(@experiment) %>
       <button id="duplicateTasks" class="btn btn-light multiple-object-action hidden only-active" data-url="<%= batch_clone_my_modules_experiment_path(@experiment) %>">
         <i class="fas fa-copy"></i>
-        <%= t("experiments.table.toolbar.duplicate") %>
+        <span class="button-text"><%= t("experiments.table.toolbar.duplicate") %></span>
       </button>
     <% end %>
     <button id="moveTask" class="btn btn-light multiple-object-action hidden only-active" data-for="moveable">
       <i class="fas fa-arrow-right"></i>
-      <%= t("experiments.table.toolbar.move") %>
+      <span class="button-text"><%= t("experiments.table.toolbar.move") %></span>
     </button>
     <button id="archiveTask" class="btn btn-light multiple-object-action hidden only-active" data-url="<%= archive_my_modules_experiment_path(@experiment) %>"  data-for="archivable">
       <i class="fas fa-archive"></i>
-      <%= t("experiments.table.toolbar.archive") %>
+      <span class="button-text"><%= t("experiments.table.toolbar.archive") %></span>
     </button>
     <button id="restoreTask" class="btn btn-light multiple-object-action hidden only-archive" data-url="<%= restore_my_modules_experiment_path(@experiment) %>"  data-for="restorable">
       <i class="fas fa-undo"></i>
-      <%= t("experiments.table.toolbar.restore") %>
+      <span class="button-text"><%= t("experiments.table.toolbar.restore") %></span>
     </button>
   </div>
   <div class="toolbar-right-block">
     <button id="taskDataDisplay" class="btn btn-light" data-toggle="modal" data-target="#tableDisplayModal">
       <i class="fas fa-eye"></i>
-      <%= t("experiments.table.toolbar.task_data") %>
+      <span class="button-text"><%= t("experiments.table.toolbar.task_data") %></span>
     </button>
   </div>
 </div>


### PR DESCRIPTION
Jira ticket: [SCI-7737](https://scinote.atlassian.net/browse/SCI-7737)

### What was done
- [x] Hide text for action buttons in small screens (less than 1000px).



[SCI-7737]: https://scinote.atlassian.net/browse/SCI-7737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ