### PR TITLE
Properly assign team to tinymce asset when extracting base64 images [SCI-5098]

### DIFF
--- a/app/models/concerns/tiny_mce_images.rb
+++ b/app/models/concerns/tiny_mce_images.rb
@@ -179,7 +179,7 @@ module TinyMceImages
           base64_data = base64_src.split('base64,').last
 
           tiny_image = TinyMceAsset.create!(
-            team: @team,
+            team: Team.search_by_object(self),
             object: self,
             saved: true
           )


### PR DESCRIPTION


Jira ticket: [SCI-5098](https://scinote.atlassian.net/browse/SCI-5098)

### What was done
Properly assign team to tinymce asset when extracting base64 images

[SCI-5098]: https://scinote.atlassian.net/browse/SCI-5098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ