### PR TITLE
Update of sharing options to all teams is not saved [SCI-7421]

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -262,7 +262,7 @@ class Repository < RepositoryBase
         team.repository_sharing_user_assignments.find_or_create_by(
           user: user,
           assignable: self
-        ).update(user_role: shared_write? ? normal_user_role : viewer_role)
+        ).update!(user_role: shared_write? ? normal_user_role : viewer_role)
       end
     end
   end

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -259,7 +259,7 @@ class Repository < RepositoryBase
 
     Team.where.not(id: team.id).find_each do |team|
       team.users.find_each do |user|
-        team.repository_sharing_user_assignments.find_or_create_by(
+        team.repository_sharing_user_assignments.find_or_initialize_by(
           user: user,
           assignable: self
         ).update!(user_role: shared_write? ? normal_user_role : viewer_role)

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -259,11 +259,10 @@ class Repository < RepositoryBase
 
     Team.where.not(id: team.id).find_each do |team|
       team.users.find_each do |user|
-        team.repository_sharing_user_assignments.create!(
+        team.repository_sharing_user_assignments.find_or_create_by(
           user: user,
-          user_role: shared_write? ? normal_user_role : viewer_role,
           assignable: self
-        )
+        ).update(user_role: shared_write? ? normal_user_role : viewer_role)
       end
     end
   end


### PR DESCRIPTION
Jira ticket: [SCI-7421](https://scinote.atlassian.net/browse/SCI-7421)

### What was done
_while updating shared options for teams, it would not update unless we unshared the inventory itself, this was caused by user  uniqueness inside model, the logic was creating another unique one after changing editing permissions, and that was wrong, it just needed to update it_


[SCI-7421]: https://scinote.atlassian.net/browse/SCI-7421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ