### PR TITLE
Fix user assigning to teams with existing team sharing records [SCI-7720]

### DIFF
--- a/app/models/team_shared_object.rb
+++ b/app/models/team_shared_object.rb
@@ -3,7 +3,6 @@
 class TeamSharedObject < ApplicationRecord
   enum permission_level: Extends::SHARED_OBJECTS_PERMISSION_LEVELS.except(:not_shared)
 
-
   after_create :assign_shared_inventories, if: -> { shared_object.is_a?(Repository) }
   before_destroy :unassign_unshared_items, if: -> { shared_object.is_a?(Repository) }
   before_destroy :unassign_unshared_inventories, if: -> { shared_object.is_a?(Repository) }

--- a/app/services/user_assignments/create_team_user_assignments_service.rb
+++ b/app/services/user_assignments/create_team_user_assignments_service.rb
@@ -68,7 +68,7 @@ module UserAssignments
     end
 
     def create_or_update_user_assignment(object, role = nil)
-      new_user_assignment = object.user_assignments.find_or_initialize_by(user: @user)
+      new_user_assignment = object.user_assignments.find_or_initialize_by(user: @user, team: object.team)
       return if new_user_assignment.manually_assigned?
 
       new_user_assignment.user_role = role || @user_role


### PR DESCRIPTION
Jira ticket: [SCI-7720](https://scinote.atlassian.net/browse/SCI-7720)

### What was done
Fix user assigning to teams with existing team sharing records

[SCI-7720]: https://scinote.atlassian.net/browse/SCI-7720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ