### PR TITLE
Default sorting in tables is saved (user specific) [SCI-7818]

### DIFF
--- a/app/assets/javascripts/label_templates/label_templates_datatable.js
+++ b/app/assets/javascripts/label_templates/label_templates_datatable.js
@@ -236,7 +236,8 @@
     var $table = $('#label-templates-table');
     LABEL_TEMPLATE_TABLE = $table.DataTable({
       dom: "R<'label-toolbar'<'label-buttons-container'><'label-search-container'f>>t<'pagination-row hidden'<'pagination-info'li><'pagination-actions'p>>",
-      order: [[1, 'desc']],
+      order: [[2, 'desc']],
+      stateSave: true,
       sScrollX: '100%',
       sScrollXInner: '100%',
       processing: true,

--- a/app/assets/javascripts/label_templates/label_templates_datatable.js
+++ b/app/assets/javascripts/label_templates/label_templates_datatable.js
@@ -236,7 +236,7 @@
     var $table = $('#label-templates-table');
     LABEL_TEMPLATE_TABLE = $table.DataTable({
       dom: "R<'label-toolbar'<'label-buttons-container'><'label-search-container'f>>t<'pagination-row hidden'<'pagination-info'li><'pagination-actions'p>>",
-      order: [[2, 'desc']],
+      order: [[1, 'desc']],
       stateSave: true,
       sScrollX: '100%',
       sScrollXInner: '100%',

--- a/app/assets/javascripts/reports/reports_datatable.js
+++ b/app/assets/javascripts/reports/reports_datatable.js
@@ -227,6 +227,7 @@
       dom: "Rt<'pagination-row hidden'<'pagination-info'li><'pagination-actions'p>>",
       order: [[9, 'desc']],
       sScrollX: '100%',
+      stateSave: true,
       sScrollXInner: '100%',
       processing: true,
       serverSide: true,

--- a/app/assets/javascripts/repositories/index.js
+++ b/app/assets/javascripts/repositories/index.js
@@ -41,6 +41,7 @@
         aaData: data,
         dom: "R<'main-actions hidden'<'toolbar'><'filter-container'f>>t<'pagination-row hidden'<'pagination-info'li><'pagination-actions'p>>",
         processing: true,
+        stateSave: true,
         pageLength: 25,
         colReorder: {
           enable: false


### PR DESCRIPTION
Jira ticket: [SCI-7818](https://scinote.atlassian.net/browse/SCI-7818)

### What was done
 - [x] Persisted user-specific settings (sorting and pagination) via localStorage for the following data tables:
   - Label templates
   - Reports
   - Teams
   - Team members
   - Members
   - Organization - System log
   - Inventories
   - Archived inventories
   - :x: Items (one inventory) table is already done via the database
   - :x: Archived Items (of one inventory) table is already done via the database

[SCI-7818]: https://scinote.atlassian.net/browse/SCI-7818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ