### PR TITLE
Bring the user information flyout to the foreground in task panel [SCI-7832]

### DIFF
--- a/app/assets/stylesheets/themes/scinote.scss
+++ b/app/assets/stylesheets/themes/scinote.scss
@@ -1381,7 +1381,7 @@ th.custom-field .modal-tooltiptext {
   border-radius: 3px;
   min-width: 450px;
   padding: 15px 10px;
-  z-index: 9999;
+  z-index: 10001;
 
   h5 {
     font-weight: bold;


### PR DESCRIPTION
Jira ticket: [SCI-7832](https://scinote.atlassian.net/browse/SCI-7832)

### What was done
Fixed the CSS issue with the flyout being hidden behind the panel.

[SCI-7832]: https://scinote.atlassian.net/browse/SCI-7832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ