### PR TITLE
No warning message on modal, when importing existing protocol from protocols.io into My Protocols [SCI-7831]

### DIFF
--- a/app/assets/javascripts/protocols/external_protocols_tab.js
+++ b/app/assets/javascripts/protocols/external_protocols_tab.js
@@ -152,7 +152,7 @@ function showFormErrors(modal, errors) {
   Object.keys(errors.protocol).forEach(function(key) {
     var input = modal.find('#protocol_' + key);
     var msg;
-    msg = key.charAt(0).toUpperCase() + key.slice(1) + ': ' + errors.protocol[key].join(', ');
+    msg = errors.protocol[key].join(', ');
     if ((input.length > 0) && (errors.protocol[key].length > 0)) {
       input.closest('.form-group').children('span.help-block').html(msg);
       input.closest('.form-group').addClass('has-error');

--- a/app/assets/javascripts/protocols/external_protocols_tab.js
+++ b/app/assets/javascripts/protocols/external_protocols_tab.js
@@ -195,7 +195,7 @@ function handleFormSubmit(modal) {
         HelperModule.flashAlertMsg(data.message, 'success');
       },
       error: function(data) {
-        showFormErrors(modal, data.responseJSON.errors);
+        showFormErrors(modal, data.responseJSON.validation_errors);
       },
       complete: function() {
         animateSpinner(modal, false);

--- a/app/assets/stylesheets/protocols/preview_modal.scss
+++ b/app/assets/stylesheets/protocols/preview_modal.scss
@@ -13,6 +13,14 @@
     .ql-editor {
       min-height: initial;
     }
+
+    .form-group.has-error {
+      color: $brand-danger;
+
+      .sci-input-field {
+        border: 1px solid $brand-danger;
+      }
+    }
   }
 
   .general-error {

--- a/app/controllers/external_protocols_controller.rb
+++ b/app/controllers/external_protocols_controller.rb
@@ -19,7 +19,7 @@ class ExternalProtocolsController < ApplicationController
         page_id: service_call.protocols_list[:pagination][:current_page]
       }
     else
-      render json: { errors: service_call.errors }, status: 400
+      render json: { errors: service_call.errors }, status: :bad_request
     end
   end
 
@@ -43,7 +43,7 @@ class ExternalProtocolsController < ApplicationController
   rescue StandardError => e
     render json: {
       errors: [protocol_html_preview: e.message]
-    }, status: 400
+    }, status: :bad_request
   end
 
   # GET build_online_sources_protocol
@@ -74,7 +74,7 @@ class ExternalProtocolsController < ApplicationController
         validation_errors: { protocol: @protocol.errors.messages }
       }
     else
-      render json: { errors: service_call.errors }, status: 400
+      render json: { errors: service_call.errors }, status: :bad_request
     end
   end
 
@@ -95,7 +95,7 @@ class ExternalProtocolsController < ApplicationController
       render json: { protocol: service_call.protocol,
                      message: message }
     else
-      render json: { validation_errors: service_call.errors }, status: 400
+      render json: { validation_errors: service_call.errors }, status: :bad_request
     end
   end
 

--- a/app/controllers/external_protocols_controller.rb
+++ b/app/controllers/external_protocols_controller.rb
@@ -95,7 +95,7 @@ class ExternalProtocolsController < ApplicationController
       render json: { protocol: service_call.protocol,
                      message: message }
     else
-      render json: { errors: service_call.errors }, status: 400
+      render json: { validation_errors: service_call.errors }, status: 400
     end
   end
 

--- a/app/services/protocol_importers/import_protocol_service.rb
+++ b/app/services/protocol_importers/import_protocol_service.rb
@@ -39,12 +39,14 @@ module ProtocolImporters
 
           TinyMceAsset.update_images(step_text, '[]', @user)
 
-          # 'Manually' create assets here. "Accept nasted attributes" won't work for assets
+          # 'Manually' create assets here. "Accept nested attributes" won't work for assets
           step.assets << AttachmentsBuilder.generate(step_params.deep_symbolize_keys, user: @user, team: @team)
           step
         end
+      rescue ActiveRecord::RecordInvalid => invalid
+        @errors[:protocol] = invalid.record.errors
       rescue StandardError => e
-        @errors[:protocol] = format_error(e)
+        @errors[:protocol] = e.message
       end
 
       self
@@ -55,11 +57,6 @@ module ProtocolImporters
     end
 
     private
-
-    def format_error(err)
-      error_type, *error_message = err.message.split(': ')[1].split(' ')
-      { error_type.downcase.to_sym => [error_message.join(' ')] }
-    end
 
     def valid?
       unless [@protocol_params, @user, @team].all?

--- a/app/services/protocol_importers/import_protocol_service.rb
+++ b/app/services/protocol_importers/import_protocol_service.rb
@@ -56,9 +56,9 @@ module ProtocolImporters
 
     private
 
-    def format_error(e)
-      error_type, *error_message = e.message.split(': ')[1].split(' ')
-      {error_type.downcase.to_sym => [error_message.join(' ')]}
+    def format_error(err)
+      error_type, *error_message = err.message.split(': ')[1].split(' ')
+      { error_type.downcase.to_sym => [error_message.join(' ')] }
     end
 
     def valid?

--- a/app/services/protocol_importers/import_protocol_service.rb
+++ b/app/services/protocol_importers/import_protocol_service.rb
@@ -43,8 +43,8 @@ module ProtocolImporters
           step.assets << AttachmentsBuilder.generate(step_params.deep_symbolize_keys, user: @user, team: @team)
           step
         end
-      rescue ActiveRecord::RecordInvalid => invalid
-        @errors[:protocol] = invalid.record.errors
+      rescue ActiveRecord::RecordInvalid => e
+        @errors[:protocol] = e.record.errors
       rescue StandardError => e
         @errors[:protocol] = e.message
       end

--- a/app/services/protocol_importers/import_protocol_service.rb
+++ b/app/services/protocol_importers/import_protocol_service.rb
@@ -44,7 +44,7 @@ module ProtocolImporters
           step
         end
       rescue StandardError => e
-        @errors[:protocol] = e.message
+        @errors[:protocol] = format_error(e)
       end
 
       self
@@ -55,6 +55,11 @@ module ProtocolImporters
     end
 
     private
+
+    def format_error(e)
+      error_type, *error_message = e.message.split(': ')[1].split(' ')
+      {error_type.downcase.to_sym => [error_message.join(' ')]}
+    end
 
     def valid?
       unless [@protocol_params, @user, @team].all?


### PR DESCRIPTION
Jira ticket: [SCI-7831](https://scinote.atlassian.net/browse/SCI-7831)

### What was done
 - [x] Fix the style and the content of the errors when importing an external protocol with an existing name.

### **Note:**
I :100: agree that the approach I took to format the error messages in `services/protocol-importers/import_protocol_service.rb` is not clean.
Please let me know if you have any suggestions.


[SCI-7831]: https://scinote.atlassian.net/browse/SCI-7831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ