### PR TITLE
Add empty space in PDF report after asset link [SCI-7660]

### DIFF
--- a/app/views/reports/elements/_step_asset_element.html.erb
+++ b/app/views/reports/elements/_step_asset_element.html.erb
@@ -30,7 +30,7 @@
       <% end %>
     </div>
     <div class="user-time">
-      <%= t('projects.reports.elements.step_asset.user_time', timestamp: l(timestamp, format: :full)) %>
+      &nbsp;<%= t('projects.reports.elements.step_asset.user_time', timestamp: l(timestamp, format: :full)) %>
     </div>
   </div>
   <div class="report-element-body">


### PR DESCRIPTION
Jira ticket: [SCI-7660](https://scinote.atlassian.net/browse/SCI-7660)

### What was done
Add empty space in PDF report after asset link

[SCI-7660]: https://scinote.atlassian.net/browse/SCI-7660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ