### PR TITLE
Improve the print functionality for protocol [SCI-7237]

### DIFF
--- a/app/assets/stylesheets/layouts/print_protocol.scss
+++ b/app/assets/stylesheets/layouts/print_protocol.scss
@@ -55,7 +55,7 @@ hr {
 }
 
 .print-step {
-  margin: 5em 0;
+  margin: 2em 0;
 }
 
 .step-check-circle {

--- a/app/views/protocols/print.html.erb
+++ b/app/views/protocols/print.html.erb
@@ -34,7 +34,7 @@
         <% step_text = step_element.orderable %>
         <div class="print-step-text">
           <div class="ql-editor">
-          <%= custom_auto_link(step_text.tinymce_render(:text),
+          <%= custom_auto_link(step_text.tinymce_render(:text).gsub(/<p>\S<\/p>/, '').strip,
                                 simple_format: false,
                                 tags: %w(img),
                                 team: current_team,


### PR DESCRIPTION
Jira ticket: [SCI-7237](https://scinote.atlassian.net/browse/SCI-7237)

### What was done
- Reduced the amount of unnecessary whitespace in the printed protocol PDF.

### Note:
This is by no means a definite solution. Additional whitespace can result from a number of causes. Maybe we can consider a custom tool for printing instead of depending on the browser's default printing functionality.

[SCI-7237]: https://scinote.atlassian.net/browse/SCI-7237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ