### PR TITLE
Missing error message, when a user tries to save a protocol with an existing name [SCI-7839]

### DIFF
--- a/app/controllers/protocols_controller.rb
+++ b/app/controllers/protocols_controller.rb
@@ -12,6 +12,7 @@ class ProtocolsController < ApplicationController
   before_action :check_create_permissions, only: %i(
     create
   )
+  before_action :load_team_and_type, only: :show
   before_action :check_clone_permissions, only: [:clone]
   before_action :check_view_permissions, only: %i(
     show
@@ -164,6 +165,10 @@ class ProtocolsController < ApplicationController
   end
 
   def show
+    @names = Protocol.where(
+      team: @current_team,
+      protocol_type: Protocol.protocol_types[@type == :public ? :in_repository_public : :in_repository_private]
+    ).map(&:name)
     respond_to do |format|
       format.json { render json: @protocol, serializer: ProtocolSerializer, user: current_user }
       format.html

--- a/app/controllers/protocols_controller.rb
+++ b/app/controllers/protocols_controller.rb
@@ -1251,5 +1251,4 @@ class ProtocolsController < ApplicationController
       protocol_type: Protocol.protocol_types[type]
     ).map(&:name)
   end
-
 end

--- a/app/controllers/protocols_controller.rb
+++ b/app/controllers/protocols_controller.rb
@@ -12,7 +12,6 @@ class ProtocolsController < ApplicationController
   before_action :check_create_permissions, only: %i(
     create
   )
-  before_action :load_team_and_type, only: :show
   before_action :check_clone_permissions, only: [:clone]
   before_action :check_view_permissions, only: %i(
     show
@@ -165,10 +164,7 @@ class ProtocolsController < ApplicationController
   end
 
   def show
-    @names = Protocol.where(
-      team: @current_team,
-      protocol_type: Protocol.protocol_types[@type == :public ? :in_repository_public : :in_repository_private]
-    ).map(&:name)
+    @existing_names = existing_protocol_names(@protocol)
     respond_to do |format|
       format.json { render json: @protocol, serializer: ProtocolSerializer, user: current_user }
       format.html
@@ -1246,4 +1242,14 @@ class ProtocolsController < ApplicationController
                  protocol: link_to(@protocol.name, protocol_url(@protocol)))
     )
   end
+
+  def existing_protocol_names(protocol)
+    team = protocol.team
+    type = protocol.protocol_type.to_sym == :in_repository_private ? :in_repository_private : :in_repository_public
+    Protocol.where(
+      team: team,
+      protocol_type: Protocol.protocol_types[type]
+    ).map(&:name)
+  end
+
 end

--- a/app/javascript/vue/protocol/container.vue
+++ b/app/javascript/vue/protocol/container.vue
@@ -45,6 +45,7 @@
             :placeholder="i18n.t('my_modules.protocols.protocol_status_bar.enter_name')"
             :allowBlank="!inRepository"
             :attributeName="`${i18n.t('Protocol')} ${i18n.t('name')}`"
+            :names="names"
             @update="updateName"
           />
           <span v-else>
@@ -148,7 +149,8 @@
       protocolUrl: {
         type: String,
         required: true
-      }
+      },
+      names: { type: Array, required: true }
     },
     components: { Step, InlineEdit, ProtocolModals, ProtocolOptions, Tinymce, ReorderableItemsModal, ProtocolMetadata },
     mixins: [UtilsMixin],

--- a/app/javascript/vue/protocol/container.vue
+++ b/app/javascript/vue/protocol/container.vue
@@ -98,8 +98,8 @@
         </a>
       </div>
       <div class="protocol-steps">
-        <template v-for="(step, index) in steps">
-          <div class="step-block" :key="step.id">
+        <template v-for="(step, index) in steps" :key="step.id">
+          <div class="step-block">
             <div v-if="index > 0 && urls.add_step_url" class="insert-step" @click="addStep(index)">
               <i class="fas fa-plus"></i>
             </div>

--- a/app/javascript/vue/protocol/container.vue
+++ b/app/javascript/vue/protocol/container.vue
@@ -45,7 +45,7 @@
             :placeholder="i18n.t('my_modules.protocols.protocol_status_bar.enter_name')"
             :allowBlank="!inRepository"
             :attributeName="`${i18n.t('Protocol')} ${i18n.t('name')}`"
-            :names="names"
+            :names="existingNames"
             @update="updateName"
           />
           <span v-else>
@@ -150,7 +150,7 @@
         type: String,
         required: true
       },
-      names: { type: Array, required: true }
+      existingNames: { type: Array, required: true }
     },
     components: { Step, InlineEdit, ProtocolModals, ProtocolOptions, Tinymce, ReorderableItemsModal, ProtocolMetadata },
     mixins: [UtilsMixin],

--- a/app/javascript/vue/protocol/container.vue
+++ b/app/javascript/vue/protocol/container.vue
@@ -98,8 +98,8 @@
         </a>
       </div>
       <div class="protocol-steps">
-        <template v-for="(step, index) in steps" :key="step.id">
-          <div class="step-block">
+        <template v-for="(step, index) in steps">
+          <div class="step-block" :key="step.id">
             <div v-if="index > 0 && urls.add_step_url" class="insert-step" @click="addStep(index)">
               <i class="fas fa-plus"></i>
             </div>

--- a/app/javascript/vue/shared/inline_edit.vue
+++ b/app/javascript/vue/shared/inline_edit.vue
@@ -48,7 +48,8 @@
       multilinePaste: { type: Boolean, default: false },
       smartAnnotation: { type: Boolean, default: false },
       editOnload: { type: Boolean, default: false },
-      defaultValue: { type: String, default: '' }
+      defaultValue: { type: String, default: '' },
+      names: {type: Array, default: () => []}
     },
     data() {
       return {
@@ -79,6 +80,9 @@
       isBlank() {
         return this.newValue.length === 0
       },
+      nameExists() {
+        return this.names.includes(this.newValue) && this.newValue !== this.value
+      },
       error() {
         if(!this.allowBlank && this.isBlank) {
           return this.i18n.t('inline_edit.errors.blank', { attribute: this.attributeName })
@@ -99,6 +103,15 @@
               {
                 attribute: this.attributeName,
                 limit: this.numberWithSpaces(this.characterMinLimit)
+              }
+            )
+          )
+        }
+        if (this.names.length && this.nameExists) {
+          return (
+            this.i18n.t('inline_edit.errors.already_exist',
+              {
+                attribute: this.attributeName
               }
             )
           )

--- a/app/views/protocols/show.html.erb
+++ b/app/views/protocols/show.html.erb
@@ -18,7 +18,7 @@
     >
       <protocol-container
       :protocol-url="protocolUrl"
-      :names="<%= @names %>"
+      :existing-names="<%= @existing_names %>"
       />
     </div>
   </div>

--- a/app/views/protocols/show.html.erb
+++ b/app/views/protocols/show.html.erb
@@ -18,6 +18,7 @@
     >
       <protocol-container
       :protocol-url="protocolUrl"
+      :names="<%= @names %>"
       />
     </div>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3511,6 +3511,7 @@ en:
     clear_btn: "Clear"
   inline_edit:
     errors:
+      already_exist: "%{attribute} already exist"
       over_limit: "%{attribute} is too long (maximum number is %{limit} characters)"
       below_limit: "%{attribute} is too short (minimum number is %{limit} characters)"
       blank: "%{attribute} can't be empty"


### PR DESCRIPTION
Jira ticket: [SCI-7839](https://scinote.atlassian.net/browse/SCI-7839)

### What was done
Implemented the error effect and message functionality when trying to rename a protocol with an existing name.
The protocol names for which the errors are shown are dependent on the `team`, `curent_user`, and the protocol `type`.


[SCI-7839]: https://scinote.atlassian.net/browse/SCI-7839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ