### PR TITLE
CSS:Uneven spacing around the check button [SCI-7772]

### DIFF
--- a/app/assets/stylesheets/experiment/table.scss
+++ b/app/assets/stylesheets/experiment/table.scss
@@ -56,7 +56,7 @@
       border: 1px solid $color-white;
       display: flex;
       height: 3em;
-      padding: 0 .5em;
+      padding: 0 calc((3em - var(--sci-checkbox-size))/2);
       position: sticky;
       position: -webkit-sticky;
       top: 0;
@@ -83,6 +83,11 @@
 
     .table-body {
       display: contents;
+
+      .table-body-cell {
+        display: flex;
+        justify-content: center;
+      }
     }
 
     .loading-overlay {

--- a/app/assets/stylesheets/extend/datatable.scss
+++ b/app/assets/stylesheets/extend/datatable.scss
@@ -40,7 +40,11 @@
 
       th,
       td {
-        padding: 8px;
+        padding: 12px;
+
+        &:first-child {
+          width: 16px !important;
+        }
       }
     }
   }
@@ -55,6 +59,11 @@
 
     td {
       padding-left: 10px;
+
+      &:first-child {
+        display: flex;
+        justify-content: center;
+      }
     }
 
     .dt-body-center {

--- a/app/assets/stylesheets/extend/datatable.scss
+++ b/app/assets/stylesheets/extend/datatable.scss
@@ -64,6 +64,10 @@
         display: flex;
         justify-content: center;
       }
+
+      &:last-child {
+        display: table-cell;
+      }
     }
 
     .dt-body-center {

--- a/app/assets/stylesheets/shared/cards.scss
+++ b/app/assets/stylesheets/shared/cards.scss
@@ -129,7 +129,7 @@
         border: 1px solid $color-white;
         display: flex;
         height: 3em;
-        padding: 0 .5em;
+        padding: 0 calc((3em - var(--sci-checkbox-size))/2);
         position: sticky;
         position: -webkit-sticky;
         top: calc(var(--content-header-size) + var(--navbar-height));


### PR DESCRIPTION
Jira ticket: [SCI-7772](https://scinote.atlassian.net/browse/SCI-7772)

### What was done
- Fixed the spacing of both types of dataTables.
- Tested it in Chrome and Firefox

### Note:
Inventories' table behavior is somewhat different: the Checkbox column is also responsive. I imposed a fixed width for now, but maybe there is a way to do it in JS.

[SCI-7772]: https://scinote.atlassian.net/browse/SCI-7772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ