### PR TITLE
Add office file to task step - reload file option shows plain html page [SCI-7673]

### DIFF
--- a/app/javascript/vue/protocol/step_attachments/inline.vue
+++ b/app/javascript/vue/protocol/step_attachments/inline.vue
@@ -12,8 +12,8 @@
           :data-gallery-view-id="stepId"
           :data-preview-url="attachment.attributes.urls.preview"
         >
-          <span data-toggle="tooltip" 
-               data-placement="bottom" 
+          <span data-toggle="tooltip"
+               data-placement="bottom"
                :title="`${ attachment.attributes.file_name }`">
             {{ attachment.attributes.file_name }}
           </span>
@@ -44,9 +44,8 @@
       <div v-else class="empty-office-file">
         <h2>{{ i18n.t('assets.empty_office_file.description') }}</h2>
         <a :href="attachment.attributes.urls.load_asset"
-           remote="true"
            class="btn btn-primary reload-asset"
-           :params="{asset: {view_mode: attachment.attributes.view_mode}}">
+           @click.prevent="reloadAsset">
           {{ i18n.t('assets.empty_office_file.reload') }}
         </a>
       </div>
@@ -72,6 +71,7 @@
 </template>
 
 <script>
+  import axios from 'axios'
   import ContextMenuMixin from './mixins/context_menu.js';
   import ContextMenu from './context_menu.vue';
   import PdfViewer from '../../shared/pdf_viewer.vue';
@@ -89,6 +89,13 @@
         type: Number,
         required: true
       }
+    },
+    methods: {
+      reloadAsset() {
+        axios.get(this.attachment.attributes.urls.load_asset, {
+          params: { asset: { view_mode: this.attachment.attributes.view_mode } },
+        });
+      },
     },
   }
 </script>

--- a/app/javascript/vue/protocol/step_attachments/inline.vue
+++ b/app/javascript/vue/protocol/step_attachments/inline.vue
@@ -71,7 +71,6 @@
 </template>
 
 <script>
-  import axios from 'axios'
   import ContextMenuMixin from './mixins/context_menu.js';
   import ContextMenu from './context_menu.vue';
   import PdfViewer from '../../shared/pdf_viewer.vue';
@@ -92,8 +91,12 @@
     },
     methods: {
       reloadAsset() {
-        axios.get(this.attachment.attributes.urls.load_asset, {
-          params: { asset: { view_mode: this.attachment.attributes.view_mode } },
+        $.ajax({
+          method: 'GET',
+          url: this.attachment.attributes.urls.load_asset,
+          data: {
+            asset: { view_mode: this.attachment.attributes.view_mode }
+          }
         });
       },
     },

--- a/app/javascript/vue/protocol/step_attachments/mixins/wopi_file_modal.js
+++ b/app/javascript/vue/protocol/step_attachments/mixins/wopi_file_modal.js
@@ -16,7 +16,6 @@ export default {
             $wopiModal.modal('hide');
             window.open(data.edit_url, '_blank');
             window.focus();
-            window.location.reload();
           } else {
             HelperModule.flashAlertMsg(this.i18n.t('errors.general'), 'danger');
           }

--- a/app/javascript/vue/protocol/step_attachments/mixins/wopi_file_modal.js
+++ b/app/javascript/vue/protocol/step_attachments/mixins/wopi_file_modal.js
@@ -16,6 +16,7 @@ export default {
             $wopiModal.modal('hide');
             window.open(data.edit_url, '_blank');
             window.focus();
+            window.location.reload();
           } else {
             HelperModule.flashAlertMsg(this.i18n.t('errors.general'), 'danger');
           }


### PR DESCRIPTION
Jira ticket: [SCI-7673](https://scinote.atlassian.net/browse/SCI-7673)

### What was done
_click to reload file no longer goes to the plain html page, it was caused by remote="true" in vue.js,_

### Note:
_i added page refreshing after office step is added just in case, should that be removed? also this feature isn't tested so im not sure if it refreshes the file correctly since i cant test it on my dev instance_


[SCI-7673]: https://scinote.atlassian.net/browse/SCI-7673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ