### PR TITLE
Webhook execution job throws an error [SCI-7942]

### DIFF
--- a/app/services/activities/activity_filter_matching_service.rb
+++ b/app/services/activities/activity_filter_matching_service.rb
@@ -4,7 +4,7 @@ module Activities
   class ActivityFilterMatchingService
     # invert the children hash to get a hash defining parents
     ACTIVITY_SUBJECT_PARENTS = Extends::ACTIVITY_SUBJECT_CHILDREN.invert.map do |k, v|
-      k&.map { |s| [s.to_s.singularize.camelize, v] }
+      k&.map { |s| [s.to_s.classify, v.to_s.classify.constantize.reflect_on_association(s)&.inverse_of&.name || v] }
     end.compact.sum.to_h.freeze
 
     def initialize(activity)


### PR DESCRIPTION
Jira ticket: [SCI-7942](https://scinote.atlassian.net/browse/SCI-7942)

### What was done
When there is an `inverse_of` option in the association, use the new name instead of the default one:
`repository_base` becomes `repository`.

[SCI-7942]: https://scinote.atlassian.net/browse/SCI-7942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ