### PR TITLE
Fix protocol import for empty metadata [SCI-7915]

### DIFF
--- a/app/utilities/protocols_importer_v2.rb
+++ b/app/utilities/protocols_importer_v2.rb
@@ -144,7 +144,7 @@ class ProtocolsImporterV2
       table: Table.new(
         name: params['name'],
         contents: Base64.decode64(params['contents']),
-        metadata: JSON.parse(params['metadata'] || '{}'),
+        metadata: JSON.parse(params['metadata'].presence || '{}'),
         created_by: @user,
         last_modified_by: @user,
         team: @team


### PR DESCRIPTION
Jira ticket: [SCI-7915](https://scinote.atlassian.net/browse/SCI-7915)

### What was done
Fix protocol import for empty metadata

[SCI-7915]: https://scinote.atlassian.net/browse/SCI-7915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ