### PR TITLE
Fix filter_date action when only one date is present [SCI-7942]

### DIFF
--- a/app/services/activities/activity_filter_matching_service.rb
+++ b/app/services/activities/activity_filter_matching_service.rb
@@ -26,8 +26,17 @@ module Activities
 
     def filter_date!
       @activity_filters =@activity_filters.where(
-        "(CASE WHEN (filter ->> 'to_date') = '' THEN :date >= '-infinity'::date ELSE :date >= (filter ->> 'to_date')::date END) AND " \
-        "(CASE WHEN (filter ->> 'from_date') = '' THEN :date <= 'infinity'::date ELSE :date <=  (filter ->> 'from_date')::date END)",
+        "(CASE "\
+        "WHEN (filter ->> 'to_date') = '' " \
+        "THEN :date >= '-infinity'::date " \
+        "ELSE :date >= (filter ->> 'to_date')::date " \
+        "END) " \
+        " AND " \
+        "(CASE "\
+        "WHEN (filter ->> 'from_date') = '' " \
+        "THEN :date <= 'infinity'::date " \
+        "ELSE :date <=  (filter ->> 'from_date')::date "\
+        "END)",
         date: @activity.created_at.to_date
       )
     end

--- a/app/services/activities/activity_filter_matching_service.rb
+++ b/app/services/activities/activity_filter_matching_service.rb
@@ -25,7 +25,7 @@ module Activities
     private
 
     def filter_date!
-      @activity_filters =@activity_filters.where(
+      @activity_filters = @activity_filters.where(
         "(CASE "\
         "WHEN (filter ->> 'to_date') = '' " \
         "THEN :date >= '-infinity'::date " \

--- a/app/services/activities/activity_filter_matching_service.rb
+++ b/app/services/activities/activity_filter_matching_service.rb
@@ -25,10 +25,10 @@ module Activities
     private
 
     def filter_date!
-      @activity_filters = @activity_filters.where(
-        "((filter ->> 'from_date') = '' AND (filter ->> 'to_date') = '') OR " \
-        "((?)::date BETWEEN (filter ->> 'from_date')::date AND (filter ->> 'to_date')::date)",
-        @activity.created_at.to_date
+      @activity_filters =@activity_filters.where(
+        "(CASE WHEN (filter ->> 'to_date') = '' THEN :date >= '-infinity'::date ELSE :date >= (filter ->> 'to_date')::date END) AND " \
+        "(CASE WHEN (filter ->> 'from_date') = '' THEN :date <= 'infinity'::date ELSE :date <=  (filter ->> 'from_date')::date END)",
+        date: @activity.created_at.to_date
       )
     end
 


### PR DESCRIPTION
Jira ticket: [SCI-7942](https://scinote.atlassian.net/browse/SCI-7942)

### What was done
The `filter_date` action was not handling the case when only one date field (`from_date` or `to_date`) is filled in the activity filter. Changed the SQL query to fit all the edge cases.

[SCI-7942]: https://scinote.atlassian.net/browse/SCI-7942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ