### PR TITLE
Fix for scroll-to elements being hidden behind sticky navigation [SCI-7937]

### DIFF
--- a/app/assets/stylesheets/my_modules.scss
+++ b/app/assets/stylesheets/my_modules.scss
@@ -6,6 +6,11 @@
 
 @import "constants";
 
+// Fix for elements being scrolled to being hidden behind sticky navigation
+html {
+  scroll-padding-top: 128px;
+}
+
 .protocol-description-content {
   margin: 20px 0 20px 10px;
 }


### PR DESCRIPTION
Jira ticket: [SCI-7937](https://scinote.atlassian.net/browse/SCI-7937)

### What was done
Fix for scoll-to elements being hidden behind sticky navigation

[SCI-7937]: https://scinote.atlassian.net/browse/SCI-7937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ