### PR TITLE
Versions button is not connected to the actions toolbar [SCI-7991]

### DIFF
--- a/app/assets/javascripts/protocols/index.js
+++ b/app/assets/javascripts/protocols/index.js
@@ -419,21 +419,8 @@ var ProtocolsIndex = (function() {
       e.preventDefault();
     });
 
-    $(protocolsContainer).on('click', '#protocolVersions', function(e) {
-      const url = `protocols/${rowsSelected[0]}/versions_modal`;
-      $.get(url, function(data) {
-        $(protocolsContainer).append($.parseHTML(data.html));
-        $(versionsModal).modal('show');
-        inlineEditing.init();
-        $(versionsModal).find('[data-toggle="tooltip"]').tooltip();
-
-        // Remove modal when it gets closed
-        $(versionsModal).on('hidden.bs.modal', function() {
-          $(versionsModal).remove();
-        });
-      });
-      e.stopPropagation();
-      e.preventDefault();
+    $(protocolsContainer).on('click', '#protocolVersions', function() {
+      $(`tr[data-row-id=${rowsSelected[0]}] .protocol-versions-link`).click();
     });
   }
 

--- a/app/assets/javascripts/protocols/index.js
+++ b/app/assets/javascripts/protocols/index.js
@@ -23,7 +23,6 @@ var ProtocolsIndex = (function() {
   var archivedOnToFilter;
   var protocolsViewSearch;
 
-
   /**
    * Initializes page
    */
@@ -406,6 +405,23 @@ var ProtocolsIndex = (function() {
 
     protocolsTableEl.on('click', '.protocol-versions-link', function(e) {
       $.get(this.href, function(data) {
+        $(protocolsContainer).append($.parseHTML(data.html));
+        $(versionsModal).modal('show');
+        inlineEditing.init();
+        $(versionsModal).find('[data-toggle="tooltip"]').tooltip();
+
+        // Remove modal when it gets closed
+        $(versionsModal).on('hidden.bs.modal', function() {
+          $(versionsModal).remove();
+        });
+      });
+      e.stopPropagation();
+      e.preventDefault();
+    });
+
+    $(protocolsContainer).on('click', '#protocolVersions', function(e) {
+      const url = `protocols/${rowsSelected[0]}/versions_modal`;
+      $.get(url, function(data) {
         $(protocolsContainer).append($.parseHTML(data.html));
         $(versionsModal).modal('show');
         inlineEditing.init();


### PR DESCRIPTION
Jira ticket: [SCI-7991](https://scinote.atlassian.net/browse/SCI-7991)

### What was done
Open the protocol versions modal when the button on the actions toolbar is clicked.

[SCI-7991]: https://scinote.atlassian.net/browse/SCI-7991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ