### PR TITLE
Show delete button only for drafts [SCI-7997]

### DIFF
--- a/app/views/protocols/index/_protocol_versions_modal.html.erb
+++ b/app/views/protocols/index/_protocol_versions_modal.html.erb
@@ -31,9 +31,11 @@
                   <%= image_tag 'icon_small/publish.svg' %>
                   <%= t('protocols.index.versions.publish') %>
                 <% end %>
-                <div data-url="<%= destroy_draft_protocol_path(draft) %>" class="btn btn-light delete-draft">
-                  <i class="fas fa-trash"></i>
-                </div>
+                <% if can_delete_protocol_draft_in_repository?(draft) %>
+                  <div data-url="<%= destroy_draft_protocol_path(draft) %>" class="btn btn-light delete-draft">
+                    <i class="fas fa-trash"></i>
+                  </div>
+                <% end %>
               <% end %>
             </div>
             <div class="protocol-version-comment">


### PR DESCRIPTION
Jira ticket: [SCI-7997](https://scinote.atlassian.net/browse/SCI-7997)

### What was done
_changed delete button appearance on drafts only when protocol has been published_


[SCI-7997]: https://scinote.atlassian.net/browse/SCI-7997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ