### PR TITLE
Search by team does not work [SCI-7763]

### DIFF
--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -154,8 +154,7 @@ module Users
                           .where(user_assignments: { user: current_user })
                           .where('? = ANY(user_roles.permissions)', TeamPermissions::USERS_MANAGE)
                           .distinct
-
-      teams = teams.where_attributes_like(:name, params[:query]) if params[:query].present?
+      teams = teams.where_attributes_like('teams.name', params[:query]) if params[:query].present?
 
       teams.select { |team| can_invite_team_users?(team) }
 


### PR DESCRIPTION
Jira ticket: [SCI-7763](https://scinote.atlassian.net/browse/SCI-7763)

### What was done
_database was not sure which name column to use when executing the query, so i added 'team' alias to fix the problem_


[SCI-7763]: https://scinote.atlassian.net/browse/SCI-7763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ