### PR TITLE
Fix protocol id on protocol show page [SCI-8005]

### DIFF
--- a/app/serializers/protocol_serializer.rb
+++ b/app/serializers/protocol_serializer.rb
@@ -41,6 +41,10 @@ class ProtocolSerializer < ActiveModel::Serializer
     object.protocol_keywords.map { |i| { label: i.name, value: i.name } }
   end
 
+  def code
+    object&.parent&.code || object.code
+  end
+
   def description_view
     @user = @instance_options[:user]
     custom_auto_link(object.tinymce_render('description'),


### PR DESCRIPTION
Jira ticket: [SCI-8005](https://scinote.atlassian.net/browse/SCI-8005)

### What was done
Fix protocol id on the protocol show page

[SCI-8005]: https://scinote.atlassian.net/browse/SCI-8005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ