### PR TITLE
Fix duplicate keywords in protocol table [SCI-8009]

### DIFF
--- a/app/datatables/protocols_datatable.rb
+++ b/app/datatables/protocols_datatable.rb
@@ -172,7 +172,7 @@ class ProtocolsDatatable < CustomDatatable
   def get_raw_records
     get_raw_records_base.select(
       '"protocols".*',
-      'STRING_AGG("protocol_keywords"."name", \', \') AS "protocol_keywords_str"',
+      'STRING_AGG(DISTINCT("protocol_keywords"."name"), \', \') AS "protocol_keywords_str"',
       'COUNT(DISTINCT("protocol_versions"."id")) + 1 AS "nr_of_versions"', # User assignments generate duplicates
       'COUNT("protocol_drafts"."id") AS "nr_of_drafts"',
       'COUNT("user_assignments"."id") AS "nr_of_assigned_users"',


### PR DESCRIPTION
Jira ticket: [SCI-8009](https://scinote.atlassian.net/browse/SCI-8009)

### What was done
Fix duplicate keywords in protocol table

[SCI-8009]: https://scinote.atlassian.net/browse/SCI-8009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ