### PR TITLE
Fix protocol name field editability [SCI-8033]

### DIFF
--- a/app/controllers/protocols_controller.rb
+++ b/app/controllers/protocols_controller.rb
@@ -1116,6 +1116,7 @@ class ProtocolsController < ApplicationController
   end
 
   def set_inline_name_editing
+    return unless @protocol.initial_draft?
     return unless can_manage_protocol_in_repository?(@protocol)
 
     @inline_editable_title_config = {

--- a/app/models/protocol.rb
+++ b/app/models/protocol.rb
@@ -255,6 +255,10 @@ class Protocol < ApplicationRecord
         .or(team.protocols.in_repository_published_original.where(id: id))
   end
 
+  def initial_draft?
+    in_repository_draft? && parent.blank?
+  end
+
   def permission_parent
     in_module? ? my_module : team
   end


### PR DESCRIPTION
Jira ticket: [SCI-8033](https://scinote.atlassian.net/browse/SCI-8033)

### What was done
Fix protocol name field editability 

[SCI-8033]: https://scinote.atlassian.net/browse/SCI-8033?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ