### PR TITLE
Enable searching by ID when smart annotating [SCI-7944]

### DIFF
--- a/app/models/concerns/searchable_by_name_model.rb
+++ b/app/models/concerns/searchable_by_name_model.rb
@@ -34,6 +34,18 @@ module SearchableByNameModel
 
       sql_q.limit(Constants::SEARCH_LIMIT)
     end
+
+    def self.search_by_name_and_id(user, teams = [], query = nil, options = {})
+      return if user.blank? || teams.blank?
+
+      sql_q = viewable_by_user(user, teams).where(
+        "trim_html_tags(#{table_name}.name) ILIKE '%#{query.to_s}%' OR " \
+        "(#{self::PREFIXED_ID_SQL} ILIKE '#{self::ID_PREFIX}%' AND " \
+        " #{self::PREFIXED_ID_SQL} ILIKE '#{query.to_s}%') "
+      )
+
+      sql_q.limit(Constants::SEARCH_LIMIT)
+    end
   end
   # rubocop:enable Metrics/BlockLength
 end

--- a/app/models/concerns/searchable_by_name_model.rb
+++ b/app/models/concerns/searchable_by_name_model.rb
@@ -35,13 +35,13 @@ module SearchableByNameModel
       sql_q.limit(Constants::SEARCH_LIMIT)
     end
 
-    def self.search_by_name_and_id(user, teams = [], query = nil, options = {})
+    def self.search_by_name_and_id(user, teams = [], query = nil)
       return if user.blank? || teams.blank?
 
       sql_q = viewable_by_user(user, teams).where(
-        "trim_html_tags(#{table_name}.name) ILIKE '%#{query.to_s}%' OR " \
+        "trim_html_tags(#{table_name}.name) ILIKE '%#{query}%' OR " \
         "(#{self::PREFIXED_ID_SQL} ILIKE '#{self::ID_PREFIX}%' AND " \
-        " #{self::PREFIXED_ID_SQL} ILIKE '#{query.to_s}%') "
+        " #{self::PREFIXED_ID_SQL} ILIKE '#{query}%') "
       )
 
       sql_q.limit(Constants::SEARCH_LIMIT)

--- a/app/models/concerns/searchable_by_name_model.rb
+++ b/app/models/concerns/searchable_by_name_model.rb
@@ -26,18 +26,6 @@ module SearchableByNameModel
     def self.search_by_name_and_id(user, teams = [], query = nil)
       return if user.blank? || teams.blank?
 
-      sql_q = viewable_by_user(user, teams).where(
-        "trim_html_tags(#{table_name}.name) ILIKE '%#{query}%' OR " \
-        "(#{self::PREFIXED_ID_SQL} ILIKE '#{self::ID_PREFIX}%' AND " \
-        " #{self::PREFIXED_ID_SQL} ILIKE '#{query}%') "
-      )
-
-      sql_q.limit(Constants::SEARCH_LIMIT)
-    end
-
-    def self.search_by_name_and_id(user, teams = [], query = nil)
-      return if user.blank? || teams.blank?
-
       sanitized_query = ActiveRecord::Base.sanitize_sql_like(query.to_s)
 
       sql_q = viewable_by_user(user, teams).where(

--- a/app/models/concerns/searchable_by_name_model.rb
+++ b/app/models/concerns/searchable_by_name_model.rb
@@ -23,13 +23,13 @@ module SearchableByNameModel
       sql_q.limit(Constants::SEARCH_LIMIT)
     end
 
-    def self.search_by_name_and_id(user, teams = [], query = nil, options = {})
+    def self.search_by_name_and_id(user, teams = [], query = nil)
       return if user.blank? || teams.blank?
 
       sql_q = viewable_by_user(user, teams).where(
-        "trim_html_tags(#{table_name}.name) ILIKE '%#{query.to_s}%' OR " \
+        "trim_html_tags(#{table_name}.name) ILIKE '%#{query}%' OR " \
         "(#{self::PREFIXED_ID_SQL} ILIKE '#{self::ID_PREFIX}%' AND " \
-        " #{self::PREFIXED_ID_SQL} ILIKE '#{query.to_s}%') "
+        " #{self::PREFIXED_ID_SQL} ILIKE '#{query}%') "
       )
 
       sql_q.limit(Constants::SEARCH_LIMIT)

--- a/app/models/concerns/searchable_by_name_model.rb
+++ b/app/models/concerns/searchable_by_name_model.rb
@@ -22,6 +22,18 @@ module SearchableByNameModel
 
       sql_q.limit(Constants::SEARCH_LIMIT)
     end
+
+    def self.search_by_name_and_id(user, teams = [], query = nil, options = {})
+      return if user.blank? || teams.blank?
+
+      sql_q = viewable_by_user(user, teams).where(
+        "trim_html_tags(#{table_name}.name) ILIKE '%#{query.to_s}%' OR " \
+        "(#{self::PREFIXED_ID_SQL} ILIKE '#{self::ID_PREFIX}%' AND " \
+        " #{self::PREFIXED_ID_SQL} ILIKE '#{query.to_s}%') "
+      )
+
+      sql_q.limit(Constants::SEARCH_LIMIT)
+    end
   end
   # rubocop:enable Metrics/BlockLength
 end

--- a/app/models/concerns/searchable_by_name_model.rb
+++ b/app/models/concerns/searchable_by_name_model.rb
@@ -30,9 +30,8 @@ module SearchableByNameModel
 
       sql_q = viewable_by_user(user, teams).where(
         "trim_html_tags(#{table_name}.name) ILIKE ? OR " \
-        "(#{self::PREFIXED_ID_SQL} ILIKE ? AND " \
-        " #{self::PREFIXED_ID_SQL} ILIKE ?) ",
-        "%#{sanitized_query}%", "#{self::ID_PREFIX}%", "#{sanitized_query}%"
+        " #{self::PREFIXED_ID_SQL} ILIKE ? ",
+        "%#{sanitized_query}%", "%#{sanitized_query}%"
       )
 
       sql_q.limit(Constants::SEARCH_LIMIT)

--- a/app/utilities/smart_annotation.rb
+++ b/app/utilities/smart_annotation.rb
@@ -14,7 +14,7 @@ class SmartAnnotation
 
   def my_modules
     # Search tasks
-    MyModule.search_by_name(@current_user, @current_team, @query, intersect: true).active
+    MyModule.search_by_name_and_id(@current_user, @current_team, @query).active
             .joins(experiment: :project)
             .where(projects: { archived: false }, experiments: { archived: false })
             .limit(Constants::ATWHO_SEARCH_LIMIT + 1)
@@ -22,14 +22,14 @@ class SmartAnnotation
 
   def projects
     # Search projects
-    Project.search_by_name(@current_user, @current_team, @query, intersect: true)
+    Project.search_by_name_and_id(@current_user, @current_team, @query)
            .where(archived: false)
            .limit(Constants::ATWHO_SEARCH_LIMIT + 1)
   end
 
   def experiments
     # Search experiments
-    Experiment.search_by_name(@current_user, @current_team, @query, intersect: true)
+    Experiment.search_by_name_and_id(@current_user, @current_team, @query)
               .joins(:project)
               .where(projects: { archived: false }, experiments: { archived: false })
               .limit(Constants::ATWHO_SEARCH_LIMIT + 1)
@@ -40,7 +40,7 @@ class SmartAnnotation
     res = RepositoryRow
           .active
           .where(repository: repository)
-          .search_by_name(@current_user, @current_team, @query, intersect: true)
+          .search_by_name_and_id(@current_user, @current_team, @query)
           .limit(Constants::ATWHO_SEARCH_LIMIT + 1)
     rep_items_list = []
     splitted_name = repository.name.gsub(/[^0-9a-z ]/i, '').split

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3179,11 +3179,11 @@ en:
 
   atwho:
     no_results:
-      projects: "Projects with this name were not found"
-      experiments: "Experiments with this name were not found"
-      my_modules: "Tasks with this name were not found"
-      repository_rows: "Items with this name were not found"
-      users: "Users with this name were not found"
+      projects: "Projects with this name/ID were not found"
+      experiments: "Experiments with this name/ID were not found"
+      my_modules: "Tasks with this name/ID were not found"
+      repository_rows: "Items with this name/ID were not found"
+      users: "Users with this name/ID were not found"
       description: "Please make sure there are no typos, or erase letters one by one unless you see some results"
     projects: PROJECTS
     experiments: EXPERIMENTS

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3183,7 +3183,7 @@ en:
       experiments: "Experiments with this name/ID were not found"
       my_modules: "Tasks with this name/ID were not found"
       repository_rows: "Items with this name/ID were not found"
-      users: "Users with this name/ID were not found"
+      users: "Users with this name were not found"
       description: "Please make sure there are no typos, or erase letters one by one unless you see some results"
     projects: PROJECTS
     experiments: EXPERIMENTS


### PR DESCRIPTION
Jira ticket: [SCI-7944](https://scinote.atlassian.net/browse/SCI-7944)

### What was done
- [x] Implemented searching by object ID when smart annotating using `#` in fields across SciNote.


[SCI-7944]: https://scinote.atlassian.net/browse/SCI-7944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ