### PR TITLE
Old buttons at importing protocols.io protocol [SCI-8032]

### DIFF
--- a/app/assets/javascripts/protocols/protocolsio.js
+++ b/app/assets/javascripts/protocols/protocolsio.js
@@ -34,6 +34,7 @@ function applyClickCallbackOnProtocolCards() {
           $('.full-preview-panel').attr('data-url', currProtocolCard.data('url'));
           $('.full-preview-panel').attr('data-protocol-source', currProtocolCard.data('protocol-source'));
           $('.full-preview-panel').attr('data-id', currProtocolCard.data('id'));
+          $('.full-preview-panel').data('id', currProtocolCard.data('id'));
           $('.convert-protocol').attr('disabled', false);
 
           // Set base tag to account for relative links in the iframe

--- a/app/assets/stylesheets/protocols/preview_modal.scss
+++ b/app/assets/stylesheets/protocols/preview_modal.scss
@@ -26,4 +26,43 @@
   .general-error {
     text-align: center;
   }
+
+  .modal-footer {
+    .footer {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+
+      .left-section {
+        display: flex;
+        justify-content: space-between;
+        column-gap: 32px;
+
+        .default-role-container {
+          display: flex;
+          align-items: center;
+          column-gap: 8px;
+        }
+
+        .sci-input-container {
+          display: flex;
+          align-items: center;
+          flex-grow: 1;
+          column-gap: 12px;
+
+          label {
+            white-space: nowrap;
+            margin-bottom: 0;
+          }
+        }
+      }
+
+      .right-section {
+        display: flex;
+        justify-content: flex-end;
+        flex-basis: 0;
+        column-gap: 8px;
+      }
+    }
+  }
 }

--- a/app/assets/stylesheets/protocols/preview_modal.scss
+++ b/app/assets/stylesheets/protocols/preview_modal.scss
@@ -29,39 +29,39 @@
 
   .modal-footer {
     .footer {
+      align-items: center;
       display: flex;
       justify-content: space-between;
-      align-items: center;
 
       .left-section {
+        column-gap: 32px;
         display: flex;
         justify-content: space-between;
-        column-gap: 32px;
 
         .default-role-container {
-          display: flex;
           align-items: center;
           column-gap: 8px;
+          display: flex;
         }
 
         .sci-input-container {
           display: flex;
           align-items: center;
-          flex-grow: 1;
           column-gap: 12px;
+          flex-grow: 1;
 
           label {
-            white-space: nowrap;
             margin-bottom: 0;
+            white-space: nowrap;
           }
         }
       }
 
       .right-section {
-        display: flex;
-        justify-content: flex-end;
-        flex-basis: 0;
         column-gap: 8px;
+        display: flex;
+        flex-basis: 0;
+        justify-content: flex-end;
       }
     }
   }

--- a/app/views/protocol_importers/_import_form.html.erb
+++ b/app/views/protocol_importers/_import_form.html.erb
@@ -32,6 +32,8 @@
   <%= f.hidden_field(:published_on, value: protocol.published_on) %>
   <%= f.hidden_field(:description, value: protocol.description) %>
   <%= f.hidden_field(:protocol_type, value: protocol.protocol_type) %>
+  <%= f.hidden_field(:visibility) %>
+  <%= f.hidden_field(:default_public_user_role_id) %>
 
 <% end %>
 

--- a/app/views/protocol_importers/_preview_modal_footer.html.erb
+++ b/app/views/protocol_importers/_preview_modal_footer.html.erb
@@ -1,3 +1,25 @@
-<button type="button" class="btn btn-secondary" data-dismiss="modal"><%=t "general.cancel" %></button>
-<button type="button" class="btn btn-primary" data-action="import_protocol" data-import_type="in_repository_draft"><%=t "protocols.import_export.import_modal.import_to_team_protocols_label" %></button>
-<button type="button" class="btn btn-primary" data-action="import_protocol" data-import_type="in_repository_draft"><%=t "protocols.import_export.import_modal.import_to_private_protocols_label" %></button>
+<div class="footer">
+  <div class="left-section">
+    <div class="default-role-container">
+      <div class="sci-checkbox-container">
+        <%= check_box_tag "visibility", "visible", false, class: "sci-checkbox" %>
+        <span class="sci-checkbox-label"></span>
+      </div>
+      <div class="default-role-description">
+        <%= t("protocols.new_protocol_modal.access_label") %>
+      </div>
+    </div>
+    <div class="hidden" id="roleSelectWrapper">
+      <div class="sci-input-container">
+        <%= label_tag :default_public_user_role_id, t("protocols.new_protocol_modal.role_label") %>
+        <% default_role = UserRole.find_by(name: I18n.t('user_roles.predefined.viewer')).id %>
+        <%= hidden_field_tag :default_public_user_role_id, value: default_role %>
+        <%= select_tag :role_selector, options_for_select(user_roles_collection, default_role) %>
+      </div>
+    </div>
+  </div>
+  <div class="right-section">
+    <button type="button" class="btn btn-secondary" data-dismiss="modal"><%=t "general.cancel" %></button>
+    <button type="button" class="btn btn-primary" data-action="import_protocol" data-import_type="in_repository_draft"><%=t "protocols.import_export.import_modal.import_protocols_label" %></button>
+  </div>
+</div>

--- a/app/views/protocols/index.html.erb
+++ b/app/views/protocols/index.html.erb
@@ -43,6 +43,7 @@
 <%= render partial: "protocols/index/linked_children_modal.html.erb" %>
 <%= render partial: "protocols/index/protocolsio_modal.html.erb" %>
 <%= render partial: "protocols/index/new_protocol_modal.html.erb", locals: {type: 'new'} %>
+<%= render partial: "protocols/index/protocol_preview_modal.html.erb" %>
 
 <%= render partial: "protocols/import_export/import_elements.html.erb" %>
 

--- a/app/views/protocols/index/_protocolsio_modal_body.html.erb
+++ b/app/views/protocols/index/_protocolsio_modal_body.html.erb
@@ -98,7 +98,5 @@
   <button type="button" class="btn btn-primary convert-protocol" disabled><%= t('protocols.index.protocolsio.convert') %></button>
 </div>
 
-<%= render partial: "protocols/index/protocol_preview_modal.html.erb" %>
-
 <%= javascript_include_tag "protocols/steps" %>
 <%= javascript_include_tag "protocols/protocolsio.js" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2641,6 +2641,7 @@ en:
         import: "Load"
         import_to_team_protocols_label: "Import to Team Protocols"
         import_to_private_protocols_label: "Import to My Protocols"
+        import_protocols_label: "Import"
     export:
       export_results:
         title: "Export results"
@@ -2848,7 +2849,7 @@ en:
         import:
           public: "Team protocols"
           private: "My protocols"
-          success_flash: 'Protocol <strong>%{name}</strong> successfully imported to %{type}.'
+          success_flash: 'Protocol <strong>%{name}</strong> successfully imported.'
 
     steps:
       placeholder: 'Enter step name'


### PR DESCRIPTION
Jira ticket: [SCI-8032](https://scinote.atlassian.net/browse/SCI-8032)

### What was done
Implement the `protocol preview modal` importing logic with the option to add it as a public template.

#### ToDo:
- [ ] Verify that the `user-role-selector` is opening to the top.
- [x] Update the import success flash message when you get the exact text.


[SCI-8032]: https://scinote.atlassian.net/browse/SCI-8032?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ