### PR TITLE
Archived protocol template navigation, icon, button [SCI-7954]

### DIFF
--- a/app/javascript/vue/protocol/protocolMetadata.vue
+++ b/app/javascript/vue/protocol/protocolMetadata.vue
@@ -17,7 +17,7 @@
           <span class="fas fa-print" aria-hidden="true"></span>
         </a>
         <button class="btn btn-light" @click="openVersionsModal">{{ i18n.t("protocols.header.versions") }}</button>
-        <button v-if="!protocol.attributes.published" @click="$emit('publish')" class="btn btn-primary">{{ i18n.t("protocols.header.publish") }}</button>
+        <button v-if="protocol.attributes.urls.publish_url" @click="$emit('publish')" class="btn btn-primary">{{ i18n.t("protocols.header.publish") }}</button>
         <button v-if="protocol.attributes.urls.save_as_draft_url" @click="saveAsdraft" class="btn btn-secondary">{{ i18n.t("protocols.header.save_as_draft") }}</button>
       </div>
     </div>

--- a/app/serializers/protocol_serializer.rb
+++ b/app/serializers/protocol_serializer.rb
@@ -8,7 +8,7 @@ class ProtocolSerializer < ActiveModel::Serializer
 
   attributes :name, :id, :urls, :description, :description_view, :updated_at, :in_repository,
              :created_at_formatted, :updated_at_formatted, :added_by, :authors, :keywords, :version, :code,
-             :published, :version_comment
+             :published, :version_comment, :archived
 
   def updated_at
     object.updated_at.to_i

--- a/app/views/protocols/show.html.erb
+++ b/app/views/protocols/show.html.erb
@@ -22,6 +22,9 @@
                         config: @inline_editable_title_config
                       } %>
         <% else %>
+          <% if @protocol.archived %>
+            <i class="fas fa-archive"></i>&nbsp;
+          <% end %>
           <div class="name-readonly-placeholder">
             <%= @protocol.name %>
           </div>


### PR DESCRIPTION
Jira ticket: [SCI-7954](https://scinote.atlassian.net/browse/SCI-7954)

### What was done
_added logic for publish button visibility, as well as archived icon on archived protocols_

### Note:
_when protocol is archived, its other versions are not, this causes inconsistency with archived page logic, is this a desired behavior?_


[SCI-7954]: https://scinote.atlassian.net/browse/SCI-7954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ