### PR TITLE
CSS: Incorrect paddings in the "Protocol info" modal [SCI-8054]

### DIFF
--- a/app/assets/stylesheets/my_modules/protocols/index.scss
+++ b/app/assets/stylesheets/my_modules/protocols/index.scss
@@ -426,6 +426,7 @@
     left: -125px;
     max-width: 100vw;
     width: 506px;
+    padding: 15px 0;
 
     .dropdown-header,
     .dropdown-body {


### PR DESCRIPTION
Jira ticket: [SCI-8054](https://scinote.atlassian.net/browse/SCI-8054)

### What was done
_updated padding for protocol info modal_


[SCI-8054]: https://scinote.atlassian.net/browse/SCI-8054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ