### PR TITLE
Fix loading of protocols.io to protocol templates [SCI-8111]

### DIFF
--- a/app/views/protocol_importers/_preview_modal_footer.html.erb
+++ b/app/views/protocol_importers/_preview_modal_footer.html.erb
@@ -14,7 +14,7 @@
         <%= label_tag :default_public_user_role_id, t("protocols.new_protocol_modal.role_label") %>
         <% default_role = UserRole.find_by(name: I18n.t('user_roles.predefined.viewer')).id %>
         <%= hidden_field_tag :default_public_user_role_id, value: default_role %>
-        <%= select_tag :role_selector, options_for_select(user_roles_collection, default_role) %>
+        <%= select_tag :role_selector, options_for_select(user_roles_collection(@protocol), default_role) %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Jira ticket: [SCI-8111](https://scinote.atlassian.net/browse/SCI-8111)

### What was done
Fix loading of protocols.io to protocol templates

[SCI-8111]: https://scinote.atlassian.net/browse/SCI-8111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ