### PR TITLE
Display the ID of the parent protocol in reports [SCI-8081]

### DIFF
--- a/app/services/reports/docx/draw_my_module_protocol.rb
+++ b/app/services/reports/docx/draw_my_module_protocol.rb
@@ -12,7 +12,7 @@ module Reports::Docx::DrawMyModuleProtocol
     end
 
     if @settings.dig('task', 'protocol', 'description') && protocol.description.present?
-      @docx.p I18n.t('projects.reports.elements.module.protocol.user_time', code: protocol.code,
+      @docx.p I18n.t('projects.reports.elements.module.protocol.user_time', code: protocol.original_code,
                      timestamp: I18n.l(protocol.created_at, format: :full)), color: @color[:gray]
       html = custom_auto_link(protocol.description, team: @report_team)
       Reports::HtmlToWordConverter.new(@docx, { scinote_url: @scinote_url,

--- a/app/views/reports/elements/_my_module_protocol_element.html.erb
+++ b/app/views/reports/elements/_my_module_protocol_element.html.erb
@@ -10,7 +10,7 @@
       <% end %>
     </h4>
     <div class="user-time">
-      <%= t('projects.reports.elements.module.protocol.user_time', code: protocol.code, timestamp: l(protocol.created_at, format: :full)) %>
+      <%= t('projects.reports.elements.module.protocol.user_time', code: protocol.original_code, timestamp: l(protocol.created_at, format: :full)) %>
     </div>
     <div class="row module-protocol-description">
       <% if @settings.dig('task', 'protocol', 'description') && protocol.description.present? %>


### PR DESCRIPTION
Jira ticket: [SCI-8081](https://scinote.atlassian.net/browse/SCI-8081)

### What was done
_changed potocol code to protocol parent code in reports of docx and pdf_

### Note:
_it was already changed for the protocol inside my_modules_


[SCI-8081]: https://scinote.atlassian.net/browse/SCI-8081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ