### PR TITLE
Protocol permission bugs [SCI-8058]

### DIFF
--- a/app/permissions/team.rb
+++ b/app/permissions/team.rb
@@ -71,6 +71,7 @@ end
 
 Canaid::Permissions.register_for(Protocol) do
   %i(manage_protocol_in_repository
+     manage_protocol_draft_in_repository
      manage_protocol_users
      clone_protocol_in_repository
      publish_protocol_in_repository
@@ -95,7 +96,8 @@ Canaid::Permissions.register_for(Protocol) do
   end
 
   can :manage_protocol_draft_in_repository do |user, protocol|
-    protocol.permission_granted?(user, ProtocolPermissions::MANAGE_DRAFT)
+    protocol.in_repository_draft? &&
+      protocol.permission_granted?(user, ProtocolPermissions::MANAGE_DRAFT)
   end
 
   can :manage_protocol_users do |user, protocol|
@@ -132,6 +134,13 @@ Canaid::Permissions.register_for(Protocol) do
 
     %(in_repository_published_original in_repository_published_version).include?(protocol.protocol_type) &&
       (protocol.parent || protocol).draft.blank?
+  end
+
+  can :save_protocol_as_disabled_draft_in_repository do |user, protocol|
+    next false unless can_create_protocols_in_repository?(user, protocol.team)
+
+    %(in_repository_published_original in_repository_published_version).include?(protocol.protocol_type) &&
+      (protocol.parent || protocol).draft.present? && !object.archived
   end
 end
 

--- a/app/permissions/team.rb
+++ b/app/permissions/team.rb
@@ -135,13 +135,6 @@ Canaid::Permissions.register_for(Protocol) do
     %(in_repository_published_original in_repository_published_version).include?(protocol.protocol_type) &&
       (protocol.parent || protocol).draft.blank?
   end
-
-  can :save_protocol_as_disabled_draft_in_repository do |user, protocol|
-    next false unless can_create_protocols_in_repository?(user, protocol.team)
-
-    %(in_repository_published_original in_repository_published_version).include?(protocol.protocol_type) &&
-      (protocol.parent || protocol).draft.present? && !object.archived
-  end
 end
 
 Canaid::Permissions.register_for(Report) do

--- a/app/serializers/protocol_serializer.rb
+++ b/app/serializers/protocol_serializer.rb
@@ -85,15 +85,7 @@ class ProtocolSerializer < ActiveModel::Serializer
   end
 
   def disabled_drafting
-    return true if object.in_repository_draft? || object.archived?
-
-    if object.in_repository_published_version?
-      object.parent.draft.present?
-    elsif object.in_repository_published_original?
-      object.draft.present?
-    else
-      true
-    end
+    can_save_protocol_as_disabled_draft_in_repository?(object)
   end
   
   def linked

--- a/app/serializers/protocol_serializer.rb
+++ b/app/serializers/protocol_serializer.rb
@@ -85,9 +85,12 @@ class ProtocolSerializer < ActiveModel::Serializer
   end
 
   def disabled_drafting
-    can_save_protocol_as_disabled_draft_in_repository?(object)
+    return false unless can_create_protocols_in_repository?(object.team)
+
+    %(in_repository_published_original in_repository_published_version).include?(object.protocol_type) &&
+      (object.parent || object).draft.present? && !object.archived
   end
-  
+
   def linked
     object.linked?
   end


### PR DESCRIPTION
Jira ticket: [SCI-8058](https://scinote.atlassian.net/browse/SCI-8058)

### What was done
_I noticed that draft_management permission was missing some key features, so i added them, users can no longer edit published or archived protocols._

_added permission for seeing save_as_draft disabled button, we can't modify it with normal save_as_draft button as their algorithms differ in ways._

[SCI-8058]: https://scinote.atlassian.net/browse/SCI-8058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ