### PR TITLE
Fix escaping for dropdown options and keywords escaping [SCI-8137]

### DIFF
--- a/app/assets/javascripts/sitewide/dropdown_selector.js
+++ b/app/assets/javascripts/sitewide/dropdown_selector.js
@@ -541,16 +541,22 @@ var dropdownSelector = (function() {
       var customLabel = selector2.data('config').optionLabel;
       var customClass = params.optionClass || selector2.data('config').optionClass || '';
       var customStyle = selector2.data('config').optionStyle;
-      return $(`
-        <div class="dropdown-option ${customClass}" style="${customStyle ? customStyle(option) : ''}"
-          title="${(option.params && option.params.tooltip) || ''}"
-          data-params='${JSON.stringify(option.params || {})}'
-          data-label="${option.label}"
-          data-group="${group ? group.value : ''}"
-          data-value="${option.value}">
-            ${customLabel ? customLabel(option) : option.label}
-        </div>"
+      var optionElement = $(`
+        <div class="dropdown-option ${customClass}" style="${customStyle ? customStyle(option) : ''}">
+        </div>
       `);
+      optionElement
+        .attr('title', (option.params && option.params.tooltip) || '')
+        .attr('data-params', JSON.stringify(option.params || {}))
+        .attr('data-label', option.label)
+        .attr('data-group', group ? group.value : '')
+        .attr('data-value', option.value);
+      if (customLabel) {
+        optionElement.html(customLabel(option));
+      } else {
+        optionElement.html(option.label);
+      }
+      return optionElement;
     }
 
     // Draw delimiter object

--- a/app/controllers/protocols_controller.rb
+++ b/app/controllers/protocols_controller.rb
@@ -172,12 +172,6 @@ class ProtocolsController < ApplicationController
 
   def update_keywords
     respond_to do |format|
-      # sanitize user input
-      if params[:keywords]
-        params[:keywords].collect! do |keyword|
-          escape_input(keyword)
-        end
-      end
       if @protocol.update_keywords(params[:keywords])
         format.json do
           log_activity(:edit_keywords_in_protocol_repository, nil, protocol: @protocol.id)


### PR DESCRIPTION
Jira ticket: [SCI-8137](https://scinote.atlassian.net/browse/SCI-8137)

### What was done
Fix escaping for dropdown options and keywords escaping

[SCI-8137]: https://scinote.atlassian.net/browse/SCI-8137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ