### PR TITLE
Avoid double escaping in user's name on protocol and step elements [SCI-8137]

### DIFF
--- a/app/serializers/protocol_serializer.rb
+++ b/app/serializers/protocol_serializer.rb
@@ -17,7 +17,7 @@ class ProtocolSerializer < ActiveModel::Serializer
   def added_by
     {
       avatar: object.added_by&.avatar_url(:icon_small),
-      name: escape_input(object.added_by&.full_name)
+      name: object.added_by&.full_name
     }
   end
 

--- a/app/serializers/step_serializer.rb
+++ b/app/serializers/step_serializer.rb
@@ -107,6 +107,6 @@ class StepSerializer < ActiveModel::Serializer
   end
 
   def created_by
-    escape_input(object.user.full_name)
+    object.user.full_name
   end
 end


### PR DESCRIPTION
Jira ticket: [SCI-8137](https://scinote.atlassian.net/browse/SCI-8137)

### What was done
Avoid double escaping in user's name on protocol and step elements

[SCI-8137]: https://scinote.atlassian.net/browse/SCI-8137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ