### PR TITLE
Wrong error message for too long office file name [SCI-7949]

### DIFF
--- a/app/javascript/vue/protocol/step_attachments/mixins/wopi_file_modal.js
+++ b/app/javascript/vue/protocol/step_attachments/mixins/wopi_file_modal.js
@@ -21,10 +21,24 @@ export default {
           }
           requestCallback(e, data, status);
         }
-      ).on(
-        'ajax:error',
-        (e, data, status) => requestCallback(e, data, status)
-      );
+      ).on('ajax:error', function(ev, response) {
+        var element;
+        var msg;
+
+        $(this).clearFormErrors();
+
+        if (response.status === 400) {
+          element = $(this).find('#new-wopi-file-name');
+          msg = response.responseJSON.message.file.toString();
+        } else if (response.status === 403) {
+          element = $(this).find('#other-wopi-errors');
+          msg = I18n.t('assets.create_wopi_file.errors.forbidden');
+        } else if (response.status === 404) {
+          element = $(this).find('#other-wopi-errors');
+          msg = I18n.t('assets.create_wopi_file.errors.not_found');
+        }
+        renderFormError(undefined, element, msg);
+      });
     }
   }
 };


### PR DESCRIPTION
Jira ticket: [SCI-7949](https://scinote.atlassian.net/browse/SCI-7949)

### What was done
_changed error message logic to wopi file modal for steps, made it same as result ones_

### Note:
_this is an APRIL release_


[SCI-7949]: https://scinote.atlassian.net/browse/SCI-7949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ