### PR TITLE
Open the label template in the same tab [SCI-8167]

### DIFF
--- a/app/assets/javascripts/label_templates/label_templates_datatable.js
+++ b/app/assets/javascripts/label_templates/label_templates_datatable.js
@@ -39,7 +39,7 @@
     return `${data.icon_image_tag}<a
       href='${row.DT_RowAttr['data-edit-url']}'
       class='record-info-link'
-      onclick='window.open(this.href, "_blank")'
+      onclick='window.location.href = this.href; return false;'
     >${data.name}</a>`;
   }
 


### PR DESCRIPTION
Jira ticket: [SCI-8167](https://scinote.atlassian.net/browse/SCI-8167)

### What was done
_label templates show page now loads in same tab instead of opening a new one_
