### PR TITLE
Transfer protocol linked_at timestamp when cloning tasks [SCI-8256]

### DIFF
--- a/app/models/protocol.rb
+++ b/app/models/protocol.rb
@@ -574,18 +574,12 @@ class Protocol < ApplicationRecord
     if linked?
       clone.added_by = current_user
       clone.parent = parent
+      clone.linked_at = linked_at
     end
 
     ActiveRecord::Base.no_touching do
       clone = deep_clone(clone, current_user)
     end
-
-    if linked?
-      clone.updated_at = Time.zone.now
-      clone.linked_at = clone.updated_at
-      clone.save
-    end
-
     clone
   end
 


### PR DESCRIPTION
Jira ticket: [SCI-8256](https://scinote.atlassian.net/browse/SCI-8256)

### What was done
Transfer protocol linked_at timestamp when cloning tasks

[SCI-8256]: https://scinote.atlassian.net/browse/SCI-8256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ