### PR TITLE
"Recent work" link will open the 1st version of a protocol [SCI-8266]

### DIFF
--- a/app/services/dashboard/recent_work_service.rb
+++ b/app/services/dashboard/recent_work_service.rb
@@ -245,7 +245,7 @@ module Dashboard
       when 'Project'
         project_path(object_id)
       when 'Protocol'
-        protocol_path(object_id)
+        protocol_path(Protocol.find(object_id).latest_published_version_or_self.id)
       when 'RepositoryBase'
         repository_path(object_id)
       when 'Report'


### PR DESCRIPTION
Jira ticket: [SCI-8266](https://scinote.atlassian.net/browse/SCI-8266)

### What was done
Change the link to point to the last version of the protocol