### PR TITLE
Fix changing public protocol role for old protocols [SCI-8275]

### DIFF
--- a/app/models/protocol.rb
+++ b/app/models/protocol.rb
@@ -34,7 +34,9 @@ class Protocol < ApplicationRecord
     in_repository_published_version: 7
   }
 
-  auto_strip_attributes :name, :description, nullify: false
+  auto_strip_attributes :name, :description, nullify: false, if: lambda {
+                                                                   name_changed? || description_changed?
+                                                                 }
   # Name is required when its actually specified (i.e. :in_repository? is true)
   validates :name, length: { maximum: Constants::NAME_MAX_LENGTH }
   validates :description, length: { maximum: Constants::RICH_TEXT_MAX_LENGTH }


### PR DESCRIPTION
Jira ticket: [SCI-8275](https://scinote.atlassian.net/browse/SCI-8275)

### What was done
Fix changing public protocol role for old protocols 

[SCI-8275]: https://scinote.atlassian.net/browse/SCI-8275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ