### PR TITLE
Enable support of files larger than 4GB in zip [SCI-8267]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,9 @@ gem 'ajax-datatables-rails', '~> 0.3.1'
 gem 'aspector' # Aspect-oriented programming for Rails
 gem 'auto_strip_attributes', '~> 2.1' # Removes unnecessary whitespaces AR
 gem 'bcrypt', '~> 3.1.10'
-gem 'caracal' # Build docx report
+# gem 'caracal'
+gem 'caracal',
+    git: 'https://github.com/scinote-eln/caracal.git', branch: 'rubyzip2' # Build docx report
 gem 'deface', '~> 1.9'
 gem 'down', '~> 5.0'
 gem 'faker' # Generate fake data
@@ -76,7 +78,8 @@ gem 'rgl' # Graph framework for project diagram calculations
 gem 'roo', '~> 2.8.2' # Spreadsheet parser
 gem 'rotp'
 gem 'rqrcode', '~> 2.0' # QR code generator
-gem 'rubyzip'
+gem 'rubyzip', '>= 2.3.0' # will load new rubyzip version
+gem 'zip-zip' # will load compatibility for old rubyzip API.
 gem 'scenic', '~> 1.4'
 gem 'sdoc', '~> 1.0', group: :doc
 gem 'silencer' # Silence certain Rails logs

--- a/app/models/team_zip_export.rb
+++ b/app/models/team_zip_export.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'zip'
 require 'fileutils'
 require 'csv'
 

--- a/app/utilities/protocols_exporter.rb
+++ b/app/utilities/protocols_exporter.rb
@@ -1,6 +1,3 @@
-
-require 'zip'
-
 module ProtocolsExporter
   private
 

--- a/app/utilities/protocols_exporter_v2.rb
+++ b/app/utilities/protocols_exporter_v2.rb
@@ -1,5 +1,3 @@
-require 'zip'
-
 module ProtocolsExporterV2
   include ProtocolsExporter
 

--- a/config/initializers/rubyzip.rb
+++ b/config/initializers/rubyzip.rb
@@ -1,0 +1,3 @@
+require 'zip'
+
+Zip.write_zip64_support = true

--- a/config/initializers/rubyzip.rb
+++ b/config/initializers/rubyzip.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'zip'
 
 Zip.write_zip64_support = true


### PR DESCRIPTION
Jira ticket: [SCI-8267](https://scinote.atlassian.net/browse/SCI-8267)

### What was done
Update rubyzip gem to the latest version and enable support for large files (more than 4GB)



[SCI-8267]: https://scinote.atlassian.net/browse/SCI-8267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ