### PR TITLE
Label "(Draft)" in front of the protocol template name [SCI-8211]

### DIFF
--- a/app/assets/javascripts/shared/inline_editing.js
+++ b/app/assets/javascripts/shared/inline_editing.js
@@ -11,7 +11,7 @@ var inlineEditing = (function() {
       $(container.data('label-after')).appendTo(container.find('.view-mode'));
     }
 
-    if ($(container).data('params-group') === 'protocol') {
+    if ($(container).data('params-group') === 'protocol' && $(container).hasClass('inline-editing-container')) {
       $('.view-mode').text(I18n.t('protocols.draft_name', { name: $('.view-mode').text() }));
     }
   }


### PR DESCRIPTION
Jira ticket: [SCI-8211](https://scinote.atlassian.net/browse/SCI-8211)

### What was done
_when versions modal was being opened, the name was duplicating, now i added a check which only makes inline editing have this logic_


[SCI-8211]: https://scinote.atlassian.net/browse/SCI-8211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ