### PR TITLE
Fix repository_row call when no repository row is selected [SCI-8281]

### DIFF
--- a/app/assets/javascripts/sitewide/repository_row_info_modal.js
+++ b/app/assets/javascripts/sitewide/repository_row_info_modal.js
@@ -65,7 +65,7 @@
         $('#modal-info-repository-row').modal('hide');
         PrintModalComponent.row_ids = selectedRows;
       } else {
-        PrintModalComponent.row_ids = RepositoryDatatable.selectedRows();
+        PrintModalComponent.row_ids = [...RepositoryDatatable.selectedRows()];
       }
     }
   });

--- a/app/controllers/repository_rows_controller.rb
+++ b/app/controllers/repository_rows_controller.rb
@@ -307,8 +307,8 @@ class RepositoryRowsController < ApplicationController
   end
 
   def load_repository_or_snapshot
-    @repository = Repository.accessible_by_teams(current_team).find_by(id: @repository_row.first.repository_id)
-    @repository ||= RepositorySnapshot.find_by(id: @repository_row.first.repository_id)
+    @repository = Repository.accessible_by_teams(current_team).find_by(id: @repository_row&.first&.repository_id)
+    @repository ||= RepositorySnapshot.find_by(id: @repository_row&.first&.repository_id)
 
     render_404 unless @repository
   end


### PR DESCRIPTION
Jira ticket: [SCI-8281](https://scinote.atlassian.net/browse/SCI-8281)

### What was done
Fix rows_to_print call when no repository row is selected

[SCI-8281]: https://scinote.atlassian.net/browse/SCI-8281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ