### PR TITLE
Update config after protocol.io changed page_id [SCI-8286]

### DIFF
--- a/app/assets/javascripts/protocols/protocolsio.js
+++ b/app/assets/javascripts/protocols/protocolsio.js
@@ -136,7 +136,7 @@ function applySearchCallback() {
       }
       PerfectSb().update_all();
       // Reset page id after every request
-      $('form.protocols-search-bar #page-id').val(1);
+      $('form.protocols-search-bar #page-id').val(0);
 
       // Apply all callbacks on new elements
       applyClickCallbackOnProtocolCards();

--- a/app/utilities/protocol_importers/protocols_io/v3/api_client.rb
+++ b/app/utilities/protocol_importers/protocols_io/v3/api_client.rb
@@ -37,7 +37,7 @@ module ProtocolImporters
         #     Default 10.
         #   page_id (optional): int (1..n)
         #     id of page.
-        #     Default is 1.
+        #     Default is 1. (the first page_id: 0)
         def protocol_list(query_params = {})
           local_sorting = false
           response = with_handle_network_errors do

--- a/app/views/protocols/index/_protocolsio_modal_body.html.erb
+++ b/app/views/protocols/index/_protocolsio_modal_body.html.erb
@@ -13,7 +13,7 @@
           class: 'protocols-search-bar',
           remote: true do %>
           <%= hidden_field_tag 'protocol_source', 'protocolsio/v3' %>
-          <%= hidden_field_tag 'page_id', 1, id: 'page-id' %>
+          <%= hidden_field_tag 'page_id', 0, id: 'page-id' %>
           <div class='header'>
             <div class='protocols-search-bar-panel'>
               <div class='sci-input-container left-icon'>

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -272,7 +272,7 @@ class Constants
           order_field: :activity,
           order_dir: :desc,
           page_size: 50,
-          page_id: 1,
+          page_id: 0,
           fields: 'id,title,authors,created_on,uri,stats,published_on'
         }
       },


### PR DESCRIPTION
Jira ticket: [SCI-8286](https://scinote.atlassian.net/browse/SCI-8286)

### What was done
The first `page_id` in protocols.io returned results is 0 instead of 1 (probably changed recently).
I made changes to accommodate this modification.

[SCI-8286]: https://scinote.atlassian.net/browse/SCI-8286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ