### PR TITLE
Inventories: side menu overlapping with selected inventory screen [SCI-7501]

### DIFF
--- a/app/assets/stylesheets/repositories.scss
+++ b/app/assets/stylesheets/repositories.scss
@@ -10,7 +10,6 @@
 
 .repository-show {
   height: calc(100vh - var(--navbar-height));
-  left: var(--repository-sidebar-margin);
   margin: 0;
   padding: 0 2em;
   position: absolute;
@@ -37,7 +36,6 @@
       background-color: $color-white;
       border: 0;
       display: flex;
-      left: var(--repository-sidebar-margin);
       margin-left: 0em;
       padding: 0 2em;
       position: fixed;
@@ -161,7 +159,6 @@
     bottom: 0;
     display: flex;
     height: 5em;
-    left: var(--repository-sidebar-margin);
     padding: 0 2em;
     position: fixed;
     transition: .4s $timing-function-sharp;

--- a/app/assets/stylesheets/repository/repository_toolbar.scss
+++ b/app/assets/stylesheets/repository/repository_toolbar.scss
@@ -9,7 +9,6 @@
     flex-grow: 1;
     flex-wrap: nowrap;
     height: 6em;
-    left: var(--repository-sidebar-margin);
     padding: 1em 2em 0;
     position: fixed;
     top: calc(4em + var(--navbar-height));


### PR DESCRIPTION
Jira ticket: [SCI-7501](https://scinote.atlassian.net/browse/SCI-7501)

### What was done
Sync the state of the sidebar with that of the main content for `repositories` and `repository_rows`.

[SCI-7501]: https://scinote.atlassian.net/browse/SCI-7501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ