### PR TITLE
Broken CSS after clicking link from error page [SCI-7665]

### DIFF
--- a/public/403.html
+++ b/public/403.html
@@ -98,7 +98,7 @@
   </style>
 </head>
 
-<body>
+<body data-turbolinks="false">
   <!-- This file lives in public/403.html -->
   <div class="navbar">
     <a href="/">

--- a/public/404.html
+++ b/public/404.html
@@ -65,7 +65,7 @@
     </style>
   </head>
 
-  <body>
+  <body data-turbolinks="false">
     <!-- This file lives in public/404.html -->
     <div class="navbar">
       <a href="/">

--- a/public/422.html
+++ b/public/422.html
@@ -65,7 +65,7 @@
     </style>
   </head>
 
-  <body>
+  <body data-turbolinks="false">
     <!-- This file lives in public/422.html -->
     <div class="navbar">
       <a href="/">

--- a/public/500.html
+++ b/public/500.html
@@ -65,7 +65,7 @@
     </style>
   </head>
 
-  <body>
+  <body data-turbolinks="false">
     <!-- This file lives in public/500.html -->
     <div class="navbar">
     <a href="/">

--- a/public/maintenance.html
+++ b/public/maintenance.html
@@ -99,7 +99,7 @@
     </style>
   </head>
 
-  <body>
+  <body data-turbolinks="false">
     <!-- This file lives in public/maintenance.html -->
     <div class="navbar">
       <a href="/">


### PR DESCRIPTION
Jira ticket: [SCI-7665](https://scinote.atlassian.net/browse/SCI-7665)

### What was done
Disabled `turbolinks` in all error pages.

[SCI-7665]: https://scinote.atlassian.net/browse/SCI-7665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ