### PR TITLE
Replacement of "comments" icon with text "Comments" [SCI-8342]

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1381,7 +1381,7 @@ en:
         status_html: 'Status'
         assigned_html: 'Assigned to'
         tags_html: 'Tags'
-        comments_html: '<i data-toggle="tooltip" data-placement="left" title="Comments" class="fas fa-comment"></i>'
+        comments_html: 'Comments'
       modal_move_modules:
         title: "Move task(s) to experiment"
         confirm: "Move"


### PR DESCRIPTION
Jira ticket: [SCI-8342](https://scinote.atlassian.net/browse/SCI-8342)

### What was done
Replaced the header icon in the tasks table with text instead of an icon.


[SCI-8342]: https://scinote.atlassian.net/browse/SCI-8342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ