### PR TITLE
Extend flash messages for direct task items assignment [SCI-8443]

### DIFF
--- a/app/controllers/my_module_repositories_controller.rb
+++ b/app/controllers/my_module_repositories_controller.rb
@@ -74,9 +74,7 @@ class MyModuleRepositoriesController < ApplicationController
                                                                  repository: @repository,
                                                                  user: current_user,
                                                                  params: params)
-    if service.succeed? &&
-       (service.assigned_rows_count.positive? ||
-         service.unassigned_rows_count.positive?)
+    if service.succeed?
       flash = update_flash_message(service)
       status = :ok
     else
@@ -89,6 +87,7 @@ class MyModuleRepositoriesController < ApplicationController
         render json: {
           flash: flash,
           rows_count: @my_module.repository_rows_count(@repository),
+          assigned_count: service.assigned_rows_count,
           repository_id: @repository.repository_snapshots.find_by(selected: true)&.id || @repository.id
         }, status: status
       end

--- a/app/javascript/vue/assign_items_to_tasks_modal/container.vue
+++ b/app/javascript/vue/assign_items_to_tasks_modal/container.vue
@@ -276,7 +276,7 @@ export default {
         data: { rows_to_assign: this.rowsToAssign }
       }).done(({assigned_count}) => {
         const skipped_count = this.rowsToAssign.length - assigned_count;
-        console.log(skipped_count);
+
         if (skipped_count) {
           HelperModule.flashAlertMsg(this.i18n.t('repositories.modal_assign_items_to_task.assign.flash_some_assignments_success', {assigned_count: assigned_count, skipped_count: skipped_count }), 'success');
         } else {

--- a/app/javascript/vue/assign_items_to_tasks_modal/container.vue
+++ b/app/javascript/vue/assign_items_to_tasks_modal/container.vue
@@ -113,7 +113,7 @@
             :disabled="!selectedTask"
             @click="assign"
           >
-            {{ i18n.t("repositories.modal_assign_items_to_task.assign") }}
+            {{ i18n.t("repositories.modal_assign_items_to_task.assign.text") }}
           </button>
         </div>
       </div>
@@ -274,6 +274,16 @@ export default {
         type: "PATCH",
         dataType: "json",
         data: { rows_to_assign: this.rowsToAssign }
+      }).done(({assigned_count}) => {
+        const skipped_count = this.rowsToAssign.length - assigned_count;
+        console.log(skipped_count);
+        if (skipped_count) {
+          HelperModule.flashAlertMsg(this.i18n.t('repositories.modal_assign_items_to_task.assign.flash_some_assignments_success', {assigned_count: assigned_count, skipped_count: skipped_count }), 'success');
+        } else {
+          HelperModule.flashAlertMsg(this.i18n.t('repositories.modal_assign_items_to_task.assign.flash_all_assignments_success', {count: assigned_count}), 'success');
+        }
+      }).fail(() => {
+        HelperModule.flashAlertMsg(this.i18n.t('repositories.modal_assign_items_to_task.assign.flash_assignments_failure'), 'danger');
       }).always(() => {
         this.resetSelectors();
         this.deselectRows();

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1991,7 +1991,11 @@ en:
           label: "Task"
           placeholder: "Enter Task name"
           disabled_placeholder: "Select Experiment to enable Task"
-      assign: "Assign to this task"
+      assign:
+        text: "Assign to this task"
+        flash_all_assignments_success: "Successfully assigned %{count} item(s) to the task."
+        flash_some_assignments_success: "Successfully assigned %{assigned_count} item(s) to the task. %{skipped_count} item(s) were already assigned to the task."
+        flash_assignments_failure: "Failed to assign item(s) to task."
     modal_delete_record:
       title: "Delete items"
       notice: "Are you sure you want to delete the selected item(s)?"


### PR DESCRIPTION
Jira ticket: [SCI-8443](https://scinote.atlassian.net/browse/SCI-8443)

### What was done
Update item assignment modal flash messages.

### Note
the `my_module_repositories_controller#update` was changed to render more data.

[SCI-8443]: https://scinote.atlassian.net/browse/SCI-8443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ