### PR TITLE
File drop area font size is incorrect [SCI-8332]

### DIFF
--- a/app/views/result_assets/_new.html.erb
+++ b/app/views/result_assets/_new.html.erb
@@ -3,7 +3,7 @@
     <div id="new-result-assets-select" class="text-center new-asset-box">
       <span>
         <label>
-        <h2 class="inline-block"><%= t('assets.drag_n_drop.label_html') %></h2>
+        <h2 class="inline-block font-normal"><%= t('assets.drag_n_drop.label_html') %></h2>
           <span class="btn btn-default new-asset-upload-button">
             <span class="fas fa-file-upload new-asset-upload-icon"></span>
             <%= t('assets.drag_n_drop.browse_label') %>


### PR DESCRIPTION
Jira ticket: [SCI-8332](https://scinote.atlassian.net/browse/SCI-8332)

### What was done
_changed font weight to normal_


[SCI-8332]: https://scinote.atlassian.net/browse/SCI-8332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ