### PR TITLE
Fix: Whitelist New Relic srcs [SCI-8500]

### DIFF
--- a/config/initializers/extends.rb
+++ b/config/initializers/extends.rb
@@ -553,6 +553,8 @@ class Extends
     https://www.protocols.io/
     http://127.0.0.1:9100/available
     https://marvinjs.chemicalize.com/
+    newrelic.com
+    *.newrelic.com
   )
 end
 


### PR DESCRIPTION
Jira ticket: [SCI-8500](https://scinote.atlassian.net/browse/SCI-8500)

### What was done
Added the new Relic scripts to the list of whitelisted URLs

[SCI-8500]: https://scinote.atlassian.net/browse/SCI-8500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ