### PR TITLE
Active state selected by default when viewing archived content [SCI-8533]

### DIFF
--- a/app/views/projects/show/_experiment_card.html.erb
+++ b/app/views/projects/show/_experiment_card.html.erb
@@ -24,7 +24,11 @@
     <div class="workflow-img-wrapper" list-render="true">
       <%= render partial: 'projects/show/experiment_workflow_image_container', locals: { experiment: experiment } %>
     </div>
-    <%= link_to experiment.name, my_modules_experiment_path(experiment), title: experiment.name, class: 'name-link' %>
+    <% if experiment.archived? %>
+      <%= link_to experiment.name, module_archive_experiment_url(experiment), title: experiment.name, class: 'name-link' %>
+    <% else %>
+      <%= link_to experiment.name, my_modules_experiment_url(experiment), title: experiment.name, class: 'name-link' %>
+    <% end %>
   </div>
   <div class="dates-and-img-container">
     <div class="dates-container">

--- a/app/views/projects/show/_experiment_card.html.erb
+++ b/app/views/projects/show/_experiment_card.html.erb
@@ -24,7 +24,7 @@
     <div class="workflow-img-wrapper" list-render="true">
       <%= render partial: 'projects/show/experiment_workflow_image_container', locals: { experiment: experiment } %>
     </div>
-    <% if experiment.archived? %>
+    <% if experiment.archived_branch? %>
       <%= link_to experiment.name, module_archive_experiment_url(experiment), title: experiment.name, class: 'name-link' %>
     <% else %>
       <%= link_to experiment.name, my_modules_experiment_url(experiment), title: experiment.name, class: 'name-link' %>


### PR DESCRIPTION
Jira ticket: [SCI-8533](https://scinote.atlassian.net/browse/SCI-8533)

### What was done
When clicking on the archived experiment, redirect to the archived state in the task list.

[SCI-8533]: https://scinote.atlassian.net/browse/SCI-8533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ