### PR TITLE
Missing tooltips on the bottom action toolbar [SCI-8520]

### DIFF
--- a/app/javascript/vue/components/action_toolbar.vue
+++ b/app/javascript/vue/components/action_toolbar.vue
@@ -8,6 +8,7 @@
         <a :class="`btn btn-light ${action.button_class}`"
           :href="(['link', 'remote-modal']).includes(action.type) ? action.path : '#'"
           :id="action.button_id"
+          :title="action.label"
           :data-url="action.path"
           :data-object-type="action.item_type"
           :data-object-id="action.item_id"


### PR DESCRIPTION
Jira ticket: [SCI-8520](https://scinote.atlassian.net/browse/SCI-8520)

### What was done
_added tooltips to bottom aciton toolbars_


[SCI-8520]: https://scinote.atlassian.net/browse/SCI-8520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ