### PR TITLE
Assign to task modal: Add placeholder text to the projects dropdown [SCI-8544]

### DIFF
--- a/app/javascript/vue/assign_items_to_tasks_modal/container.vue
+++ b/app/javascript/vue/assign_items_to_tasks_modal/container.vue
@@ -48,6 +48,11 @@
                   'repositories.modal_assign_items_to_task.body.project_select.placeholder'
                 )
               "
+              :no-options-placeholder="
+                i18n.t(
+                  'repositories.modal_assign_items_to_task.body.project_select.no_options_placeholder'
+                )
+              "
               :searchPlaceholder="
                 i18n.t(
                   'repositories.modal_assign_items_to_task.body.project_select.placeholder'

--- a/app/javascript/vue/shared/select.vue
+++ b/app/javascript/vue/shared/select.vue
@@ -62,7 +62,7 @@
         setTimeout(() => {
           this.isOpen = false;
           this.$emit('blur');
-        }, 200)
+        }, 200);
       },
       toggle() {
         this.isOpen = !this.isOpen;

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1988,6 +1988,7 @@ en:
         project_select:
           label: "Project"
           placeholder: "Enter project name"
+          no_options_placeholder: "No projects available to select"
         experiment_select:
           label: "Experiment"
           placeholder: "Enter Experiment name"


### PR DESCRIPTION
Jira ticket: [SCI-8544](https://scinote.atlassian.net/browse/SCI-8544)

### What was done
Add a no-options placeholder for the projects selector

[SCI-8544]: https://scinote.atlassian.net/browse/SCI-8544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ