### PR TITLE
Update Tika to 2.8.0 [SCI-8363]

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,7 +58,7 @@ GIT
 
 GIT
   remote: https://github.com/scinote-eln/yomu
-  revision: 019e7cf6e29c066f0a35100be2031947324f4b2b
+  revision: 020ab670b2919f3b436e926a890d1dad23d75676
   branch: master
   specs:
     yomu (0.2.4)


### PR DESCRIPTION
Jira ticket: [SCI-8363](https://scinote.atlassian.net/browse/SCI-8363)

### What was done
Update Tika to 2.8.0

[SCI-8363]: https://scinote.atlassian.net/browse/SCI-8363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ