### PR TITLE
FIle/step dropdown is out of task border (fix) [SCI-8347]

### DIFF
--- a/app/assets/stylesheets/protocols/protocol.scss
+++ b/app/assets/stylesheets/protocols/protocol.scss
@@ -31,6 +31,10 @@
     padding: 10px 10px 10px 26px;
   }
 
+  .dropdown-menu {
+    z-index: 9;
+  }
+
   .protocol-section {
     margin: 16px 0 16px -20px;
 


### PR DESCRIPTION
Jira ticket: [SCI-8347](https://scinote.atlassian.net/browse/SCI-8347)

### What was done
- [x] [MISSED] Fix dropdown z-index in protocol templates


[SCI-8347]: https://scinote.atlassian.net/browse/SCI-8347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ