### PR TITLE
Improve behavior on project page for team admin user role [SCI-8381]

### DIFF
--- a/app/assets/stylesheets/projects.scss
+++ b/app/assets/stylesheets/projects.scss
@@ -747,6 +747,12 @@ li.module-hover {
 
             a {
               color: inherit;
+
+              &.disabled {
+                pointer-events: none;
+                color: $color-alto;
+                text-decoration: none;
+              }
             }
 
             .name {

--- a/app/assets/stylesheets/projects.scss
+++ b/app/assets/stylesheets/projects.scss
@@ -749,8 +749,8 @@ li.module-hover {
               color: inherit;
 
               &.disabled-link {
-                pointer-events: none;
                 color: $color-alto;
+                pointer-events: none;
                 text-decoration: none;
 
                 .name {

--- a/app/assets/stylesheets/projects.scss
+++ b/app/assets/stylesheets/projects.scss
@@ -748,10 +748,14 @@ li.module-hover {
             a {
               color: inherit;
 
-              &.disabled {
+              &.disabled-link {
                 pointer-events: none;
                 color: $color-alto;
                 text-decoration: none;
+
+                .name {
+                  color: $color-alto;
+                }
               }
             }
 

--- a/app/views/projects/index/_project_card.html.erb
+++ b/app/views/projects/index/_project_card.html.erb
@@ -13,14 +13,18 @@
   </div>
 
   <div class="project-name-cell table-cell">
+    <% 
+      disabled = ''
+      disabled = 'disabled' unless can_read_project?(project)
+    %>
     <% if project.archived? %>
-      <%= link_to project_url(project, view_mode: :archived) do %>
+      <%= link_to project_url(project, view_mode: :archived), class: disabled  do %>
         <h3 class="name" title="<%= project.name %>">
           <%= project.name %>
         </h3>
       <% end %>
     <% else %>
-      <%= link_to project_url(project) do %>
+      <%= link_to project_url(project), class: 'disabled' do %>
         <h3 class="name" title="<%= project.name %>">
           <%= project.name %>
         </h3>

--- a/app/views/projects/index/_project_card.html.erb
+++ b/app/views/projects/index/_project_card.html.erb
@@ -14,17 +14,16 @@
 
   <div class="project-name-cell table-cell">
     <% 
-      disabled = ''
-      disabled = 'disabled' unless can_read_project?(project)
+      disabled_link = 'disabled-link' unless project.permission_granted?(current_user, ProjectPermissions::READ)
     %>
     <% if project.archived? %>
-      <%= link_to project_url(project, view_mode: :archived), class: disabled  do %>
+      <%= link_to project_url(project, view_mode: :archived), class: disabled_link  do %>
         <h3 class="name" title="<%= project.name %>">
           <%= project.name %>
         </h3>
       <% end %>
     <% else %>
-      <%= link_to project_url(project), class: 'disabled' do %>
+      <%= link_to project_url(project), class: disabled_link do %>
         <h3 class="name" title="<%= project.name %>">
           <%= project.name %>
         </h3>


### PR DESCRIPTION
Jira ticket: [SCI-8381](https://scinote.atlassian.net/browse/SCI-8381)

### What was done
Disabled the project name link for projects that the team admin doesn’t have access to, but sees on the projects page. 


[SCI-8381]: https://scinote.atlassian.net/browse/SCI-8381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ