### PR TITLE
Prevent closing assign modal from inventory for dropdown options [SCI-8640]

### DIFF
--- a/app/javascript/vue/shared/select.vue
+++ b/app/javascript/vue/shared/select.vue
@@ -14,7 +14,7 @@
       <template v-if="options.length">
         <div
           v-for="option in options"
-          :key="option[0]" @mousedown.stop="setValue(option[0])"
+          :key="option[0]" @mousedown.prevent.stop="setValue(option[0])"
           class="sn-select__option"
         >
           {{ option[1] }}


### PR DESCRIPTION
Jira ticket: [SCI-8640](https://scinote.atlassian.net/browse/SCI-8640)

### What was done
Prevent closing assign modal from inventory for dropdown options 

[SCI-8640]: https://scinote.atlassian.net/browse/SCI-8640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ