### PR TITLE
Stretched image on the empty dashboard screen [SCI-8641]

### DIFF
--- a/app/assets/stylesheets/themes/scinote.scss
+++ b/app/assets/stylesheets/themes/scinote.scss
@@ -41,10 +41,14 @@ table {
 #no-teams-jumbotron {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  position: relative;
-  top: 100px;
   justify-content: center;
+  align-items: center;
+  padding-top: 7rem;
+
+  img {
+    margin-bottom: 1.5rem;
+    max-width: 33%;
+  }
 }
 
 #alert-container {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -86,7 +86,7 @@
         <% if user_signed_in? && current_user.teams.blank? && !(activities_are_selected? || settings_are_selected?) %>
           <!-- If member of no teams -->
           <div id="no-teams-jumbotron" class="jumbotron">
-            <%= image_tag "empty-screen-illustration.png", size: "500x500" %>
+            <%= image_tag "empty-screen-illustration.png" %>
             <h2><%=t 'general.no_teams.title' %></h2>
             <p class="no-teams-info"><%=t 'general.no_teams.text' %></p>
           </div>


### PR DESCRIPTION
Jira ticket: [SCI-8641](https://scinote.atlassian.net/browse/SCI-8641)

### What was done
Fix image size and position in no-teams-jumbotron.


[SCI-8641]: https://scinote.atlassian.net/browse/SCI-8641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ