### PR TITLE
Limit execution time of file text extraction jobs to 5 minutes [SCI-8718]

### DIFF
--- a/app/jobs/asset_text_extraction_job.rb
+++ b/app/jobs/asset_text_extraction_job.rb
@@ -1,0 +1,20 @@
+AssetTextExtractionJob = Struct.new(:asset_id, :in_template) do
+  def perform
+    asset = Asset.find_by(id: asset_id)
+    return unless asset.present? && asset.file.attached?
+
+    asset.extract_asset_text(in_template)
+  end
+
+  def queue_name
+    'assets'
+  end
+
+  def max_attempts
+    1
+  end
+
+  def max_run_time
+    5.minutes
+  end
+end


### PR DESCRIPTION
Jira ticket: [SCI-8718](https://scinote.atlassian.net/browse/SCI-8718)

### What was done
Limit execution time of file text extraction jobs to 5 minutes

[SCI-8718]: https://scinote.atlassian.net/browse/SCI-8718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ