### PR TITLE
Fix avatar image width in smart anotation pop op [SCI-8741]

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -322,7 +322,7 @@ const renderUserNamePopover = (url, fullName, email, html) => {
   return `<div class="user-name-popover-wrapper">
             <div class='col-xs-3'>
               <img
-                class='avatar'
+                class='avatar img-responsive'
                 src='${url}'
                 alt='thumb'>
             </div>


### PR DESCRIPTION
Jira ticket: [SCI-8741](https://scinote.atlassian.net/browse/SCI-8741)

### What was done
I added styles to contain user avatar width in the smart annotation pop up

#### ToDo:
N/A

### Note:
N/A


[SCI-8741]: https://scinote.atlassian.net/browse/SCI-8741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ