### PR TITLE
Unified paddings for collapsing content at printers pages [SCI-8787]

### DIFF
--- a/app/assets/stylesheets/settings/label_printers.scss
+++ b/app/assets/stylesheets/settings/label_printers.scss
@@ -47,21 +47,10 @@
   }
 
   .zebra-settings-collapse {
-    border-left: 3px solid $color-concrete;
-    margin-top: 14px;
-    padding-bottom: 0;
-    padding-top: 0;
-
-    .collapse {
-      padding-left: 2.5em;
-
+    .collapse-content {
       ol {
         padding-left: 1.5em;
       }
-    }
-
-    .collapse-row {
-      padding-left: 1em;
     }
 
     li:last-child {
@@ -94,10 +83,6 @@
     }
   }
 
-  .collapse {
-    margin-bottom: 1em;
-  }
-
   .sn-icon-down {
     cursor: pointer;
     margin-right: .25em;
@@ -108,12 +93,14 @@
   }
 
   .collapse-row {
+    padding-left: 1em;
     align-items: center;
     display: flex;
   }
 
-  .collapse {
-    padding-left: 1.5em;
+  .collapse-content {
+    padding-left: 2.5em;
+    margin-bottom: 1em;
   }
 
   .row-title {

--- a/app/assets/stylesheets/settings/label_printers.scss
+++ b/app/assets/stylesheets/settings/label_printers.scss
@@ -93,14 +93,14 @@
   }
 
   .collapse-row {
-    padding-left: 1em;
     align-items: center;
     display: flex;
+    padding-left: 1em;
   }
 
   .collapse-content {
-    padding-left: 2.5em;
     margin-bottom: 1em;
+    padding-left: 2.5em;
   }
 
   .row-title {

--- a/app/views/label_printers/_fluics_settings.html.erb
+++ b/app/views/label_printers/_fluics_settings.html.erb
@@ -4,7 +4,7 @@
       <i class="sn-icon sn-icon-down" data-toggle="collapse" href="#fluicsInstructionsSection" aria-expanded="false"></i>
       <div class="row-title"><%= t("users.settings.account.label_printer.instructions") %></div>
     </div>
-    <ul class="collapse in" id="fluicsInstructionsSection">
+    <ul class="collapse in collapse-content" id="fluicsInstructionsSection">
       <li>
         <%= t("users.settings.account.label_printer.fluics_instruction.p1") %>
       </li>
@@ -28,7 +28,7 @@
       <i class="sn-icon sn-icon-down" data-toggle="collapse" href="#SettingsSection" aria-expanded="false"></i>
       <div class="row-title"><%= t("users.settings.account.label_printer.settings") %></div>
     </div>
-    <ul class="collapse in" id="SettingsSection">
+    <ul class="collapse in collapse-content" id="SettingsSection">
       <%= form_with scope: :label_printer, url: create_fluics_label_printers_path do |form| %>
         <div class="api-key-container" data-warning="<%= t("users.settings.account.label_printer.api_key_warning") %>">
           <div class="sci-input-container <%= 'error' if flash[:error] %>" data-error-text="<%= flash[:error] %>">
@@ -63,7 +63,7 @@
         </div>
       <% end %>
     </div>
-    <ul class="collapse in" id="PrintersSection">
+    <ul class="collapse in collapse-content" id="PrintersSection">
       <% if @label_printers.any? %>
         <% @label_printers.each do |printer| %>
           <li>

--- a/app/views/label_printers/_zebra_settings.html.erb
+++ b/app/views/label_printers/_zebra_settings.html.erb
@@ -4,7 +4,7 @@
       <i class="sn-icon sn-icon-down collapsed" data-toggle="collapse" href="#zebraInstructionsSection" aria-expanded="false"></i>
       <div class="row-title"><%= t("users.settings.account.label_printer.instructions") %></div>
     </div>
-    <ul class="collapse" id="zebraInstructionsSection">
+    <ul class="collapse collapse-content" id="zebraInstructionsSection">
       <li>
         <%= t("users.settings.account.label_printer.zebra_instruction.general_html", link: Constants::SCINOTE_ZEBRA_DOWNLOAD_URL) %>
       </li>
@@ -73,7 +73,7 @@
           <% end %>
         </div>
     </div>
-    <ul class="collapse in zebra-printers" id="PrintersSection"></ul>
+    <ul class="collapse in zebra-printers collapse-content" id="PrintersSection"></ul>
   </li>
 </ul>
 


### PR DESCRIPTION
Jira ticket: [SCI-8787](https://scinote.atlassian.net/browse/SCI-8787) 

### What was done
- added class collapse-content for padding-left
- removed left vertical gray line and unified paddings for Zebra and Fluics printers
- unified the padding-left for class colapse-row



[SCI-8787]: https://scinote.atlassian.net/browse/SCI-8787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ