### PR TITLE
Protocol template print page can be accessed without permissions [SCI-8803]

### DIFF
--- a/app/controllers/protocols_controller.rb
+++ b/app/controllers/protocols_controller.rb
@@ -15,6 +15,7 @@ class ProtocolsController < ApplicationController
   before_action :check_clone_permissions, only: [:clone]
   before_action :check_view_permissions, only: %i(
     show
+    print
     versions_modal
     protocol_status_bar
     linked_children
@@ -100,9 +101,6 @@ class ProtocolsController < ApplicationController
   end
 
   def print
-    @protocol = Protocol.find(params[:id])
-    render_403 && return unless @protocol.my_module.blank? || can_read_protocol_in_module?(@protocol)
-
     render layout: 'protocols/print'
   end
 


### PR DESCRIPTION
Jira ticket: [SCI-8803](https://scinote.atlassian.net/browse/SCI-8803)

### What was done
Match protocol template print permissions to show.

[SCI-8803]: https://scinote.atlassian.net/browse/SCI-8803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ