### PR TITLE
Wrong smart annotation placeholder text at empty inventory [SCI-8514]

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3287,9 +3287,9 @@ en:
       projects: "Projects with this name/ID were not found"
       experiments: "Experiments with this name/ID were not found"
       my_modules: "Tasks with this name/ID were not found"
-      repository_rows: "Items with this name/ID were not found"
+      repository_rows: "This inventory is currently empty."
       users: "Users with this name were not found"
-      description: "Please make sure there are no typos, or erase letters one by one unless you see some results"
+      description: "Once you create items in the inventory, they will appear here."
     buttons:
       insert: "Insert"
       assign: "Assign to this task"


### PR DESCRIPTION
Jira ticket: [SCI-8514](https://scinote.atlassian.net/browse/SCI-8514)

### What was done
_changeed placeholder_


[SCI-8514]: https://scinote.atlassian.net/browse/SCI-8514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ