### PR TITLE
Fix big decimal number renderer in repository [SCI-8828]

### DIFF
--- a/app/serializers/repository_datatable/repository_number_value_serializer.rb
+++ b/app/serializers/repository_datatable/repository_number_value_serializer.rb
@@ -4,7 +4,7 @@ module RepositoryDatatable
   class RepositoryNumberValueSerializer < RepositoryBaseValueSerializer
     def value
       decimals = scope[:column].metadata.fetch('decimals', Constants::REPOSITORY_NUMBER_TYPE_DEFAULT_DECIMALS).to_i
-      value_object.data.round(decimals).to_s('F').remove(/.0+$/)
+      value_object.data.round(value_object.data.scale.zero? ? 0 : decimals)
     end
   end
 end


### PR DESCRIPTION
Jira ticket: [SCI-8828](https://scinote.atlassian.net/browse/SCI-8828)

### What was done
Fix big decimal number renderer in repository

[SCI-8828]: https://scinote.atlassian.net/browse/SCI-8828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ