### PR TITLE
Add salt to token JWT token payload [SCI-8854]

### DIFF
--- a/app/services/api/core_jwt.rb
+++ b/app/services/api/core_jwt.rb
@@ -10,6 +10,7 @@ module Api
         payload[:exp] = Rails.configuration.x.core_api_token_ttl.from_now.to_i
       end
       payload[:iss] = Rails.configuration.x.core_api_token_iss
+      payload[:salt] = SecureRandom.base64(30)
       JWT.encode(payload, KEY_SECRET, Rails.configuration.x.core_api_sign_alg)
     end
 


### PR DESCRIPTION
Jira ticket: [SCI-8854](https://scinote.atlassian.net/browse/SCI-8854)

Add salt to JWT tokens, to prevent errors if tokens are requested on the same second.


[SCI-8854]: https://scinote.atlassian.net/browse/SCI-8854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ