### PR TITLE
Avoid showing alert flash messages when redirecting from root path to sign_in [SCI-8782]

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -112,7 +112,7 @@ class Users::SessionsController < Devise::SessionsController
 
   def remove_authenticate_mesasge_if_root_path
     if session[:user_return_to] == root_path && flash[:alert] == I18n.t('devise.failure.unauthenticated')
-      flash[:alert] = nil
+      flash.clear
     end
   end
 


### PR DESCRIPTION
Jira ticket: [SCI-8782](https://scinote.atlassian.net/browse/SCI-8782)

### What was done
- clear flash messages at redirect from root path to sign in

[SCI-8782]: https://scinote.atlassian.net/browse/SCI-8782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ