### PR TITLE
Unify password dots display across browsers [SCI-8721]

### DIFF
--- a/app/assets/stylesheets/shared_styles/elements/input_fields.scss
+++ b/app/assets/stylesheets/shared_styles/elements/input_fields.scss
@@ -37,7 +37,7 @@
     }
   }
 
-  input.sci-input-field[type=password] {
+  .sci-input-field[type=password] {
     font-family: Arial;
     letter-spacing: .075em;
   }

--- a/app/assets/stylesheets/shared_styles/elements/input_fields.scss
+++ b/app/assets/stylesheets/shared_styles/elements/input_fields.scss
@@ -37,6 +37,11 @@
     }
   }
 
+  input.sci-input-field[type=password] {
+    font-family: Arial;
+    letter-spacing: .075em;
+  }
+
   .sn-icon {
     position: absolute;
     text-align: center;


### PR DESCRIPTION
Jira ticket: [SCI-8721](https://scinote.atlassian.net/browse/SCI-8721)

### What was done
- setting password input fields font to a safe font and unifying design across browsers


[SCI-8721]: https://scinote.atlassian.net/browse/SCI-8721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ