### PR TITLE
Fix team name escaping in invetories export modal [SCI-8922]

### DIFF
--- a/app/assets/javascripts/repositories/index.js
+++ b/app/assets/javascripts/repositories/index.js
@@ -162,19 +162,8 @@
   }).on('shown.bs.modal', '#export-repositories-modal', function() {
     if (!CHECKBOX_SELECTOR) return;
 
-    const selectedInventoriesCount = CHECKBOX_SELECTOR.selectedRows.length;
-    const firstDescription = $(this).find('.description-p1');
-    const teamName = firstDescription.data('team-name');
     const exportButton = $(this).find('#export-repositories-modal-submit');
     const exportURL = exportButton.data('export-url');
-
-    firstDescription.html(I18n.t(
-      'repositories.index.modal_export.description_p1_html',
-      {
-        team_name: teamName,
-        count: selectedInventoriesCount
-      }
-    ));
 
     exportButton.on('click', function() {
       $.ajax({

--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -208,6 +208,7 @@ class RepositoriesController < ApplicationController
         html: render_to_string(
           partial: 'export_repositories_modal',
           locals: { team_name: current_team.name,
+                    counter: params[:counter].to_i,
                     export_limit: TeamZipExport.exports_limit,
                     num_of_requests_left: current_user.exports_left - 1 },
           formats: :html

--- a/app/services/toolbars/repositories_service.rb
+++ b/app/services/toolbars/repositories_service.rb
@@ -63,7 +63,7 @@ module Toolbars
         label: I18n.t('libraries.index.buttons.export'),
         button_id: 'exportRepoBtn',
         icon: 'sn-icon sn-icon-export',
-        path: export_modal_team_repositories_path(@current_team),
+        path: export_modal_team_repositories_path(@current_team, counter: @repositories.length),
         type: 'remote-modal'
       }
     end

--- a/app/views/repositories/_export_repositories_modal.html.erb
+++ b/app/views/repositories/_export_repositories_modal.html.erb
@@ -11,7 +11,8 @@
         <h4 class="modal-title"><%= t('repositories.index.modal_export.title') %></h4>
       </div>
       <div class="modal-body">
-        <p class="description-p1" data-team-name="<%= team_name %>">
+        <p class="description-p1">
+          <%= t('repositories.index.modal_export.description_p1_html', team_name: team_name, count: counter) %>
         </p>
         <p class="bg-sn-super-light-blue p-3"><%= t('repositories.index.modal_export.description_alert') %></p>
         <p class="mt-3"><%= t('repositories.index.modal_export.description_p2') %></p>


### PR DESCRIPTION
Jira ticket: [SCI-8922](https://scinote.atlassian.net/browse/SCI-8922)

### What was done
Fix team name escaping in inventories export modal

[SCI-8922]: https://scinote.atlassian.net/browse/SCI-8922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ