### PR TITLE
reCAPTCHA not visible on sign-up for FREE env [SCI-8941]

### DIFF
--- a/config/initializers/extends.rb
+++ b/config/initializers/extends.rb
@@ -556,6 +556,8 @@ class Extends
     newrelic.com
     *.newrelic.com
     *.nr-data.net
+    www.recaptcha.net/
+    www.gstatic.com/recaptcha/
   )
 end
 


### PR DESCRIPTION
Jira ticket: [SCI-8941](https://scinote.atlassian.net/browse/SCI-8941)

### What was done
Whitelist reCAPTCHA scripts in content-security-policy.

[SCI-8941]: https://scinote.atlassian.net/browse/SCI-8941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ