### PR TITLE
Set dropdown at move task modal to parent width [SCI-8592]

### DIFF
--- a/app/assets/stylesheets/experiment/canvas.scss
+++ b/app/assets/stylesheets/experiment/canvas.scss
@@ -90,3 +90,9 @@
     }
   }
 }
+
+#modal-move-module {
+  .dropdown-menu {
+    max-width: 100%;
+  }
+}


### PR DESCRIPTION
Jira ticket: [SCI-8592](https://scinote.atlassian.net/browse/SCI-8592)

### What was done
- the width of the dropdown at modal for moving a task has been set to parent width - thus long names now do not over-expand the dropdown and are instead horizontally scrollable
