### PR TITLE
Group of all users from team assigned to a task are not removed when their access is removed [SCI-8587]

### DIFF
--- a/app/views/experiments/_assigned_users.html.erb
+++ b/app/views/experiments/_assigned_users.html.erb
@@ -1,4 +1,4 @@
-<% users = my_module.designated_users.order(:full_name) %>
+<% users = my_module.assigned_users.order(:full_name) %>
 <% if users.empty? && !can_manage_my_module_designated_users?(user, my_module) %>
   <%= I18n.t('experiments.table.not_set') %>
 <% else %>

--- a/app/views/user_my_modules/_index.html.erb
+++ b/app/views/user_my_modules/_index.html.erb
@@ -1,7 +1,7 @@
 <div class="select-user-container">
   <%= select_tag 'user_my_modules',
-                 options_for_select(my_module.user_my_modules.map{ |um|
-                   user = um.user
+                 options_for_select(my_module.assigned_users.map{ |um|
+                   user = um
                    [
                      user.full_name,
                      user.id,


### PR DESCRIPTION
Jira ticket: [SCI-8587](https://scinote.atlassian.net/browse/SCI-8587)

### What was done
_fixed access view when access is removed on task_


[SCI-8587]: https://scinote.atlassian.net/browse/SCI-8587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ