### PR TITLE
Share button is disabled for locked and archived tasks [SCI-8981]

### DIFF
--- a/app/javascript/vue/shareable_links/container.vue
+++ b/app/javascript/vue/shareable_links/container.vue
@@ -39,7 +39,7 @@
       },
       disabled: {
         type: Boolean,
-        defaul: true
+        default: false
       }
     },
     data() {

--- a/app/views/my_modules/protocols.html.erb
+++ b/app/views/my_modules/protocols.html.erb
@@ -50,9 +50,9 @@
           <% if current_team.shareable_links_enabled? %>
             <div class="share-task-container" data-behaviour="vue">
               <share-task-container
-                <%= 'shared' if @my_module.shared? %>
                 shareable-link-url="<%= my_module_shareable_link_path(@my_module) %>"
-                <%= 'disabled' if !can_manage_my_module?(current_user, @my_module) %> />
+                :shared="<%= @my_module.shared? %>"
+                :disabled="<%= !can_share_my_module?(@my_module) %>" />
             </div>
 
             <%= javascript_include_tag 'vue_share_task_container' %>


### PR DESCRIPTION
Jira ticket: [SCI-8981](https://scinote.atlassian.net/browse/SCI-8981)

### What was done
Make the share button independent of task status flow or archived state.

[SCI-8981]: https://scinote.atlassian.net/browse/SCI-8981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ