### PR TITLE
Add turbolinks-cache-control to no-preview [SCI-8800]

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,6 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
     <meta name="max-file-size" content="<%= Rails.configuration.x.file_max_size_mb %>">
     <meta name="tiny-mce-assets-url" content="<%= tiny_mce_assets_path %>">
+    <meta name="turbolinks-cache-control" content="no-preview">
     <% if user_signed_in? %>
       <meta name="expiration-url" content="<%= users_expire_in_path %>">
       <meta name="revive-url" content="<%= users_revive_session_path %>">


### PR DESCRIPTION
Jira ticket: [SCI-8800](https://scinote.atlassian.net/browse/SCI-8800)

### What was done
- Add meta tag with turbolinks-cache-control to no-preview and thus eliminating double loading of js files for turbolinks


[SCI-8800]: https://scinote.atlassian.net/browse/SCI-8800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ