### PR TITLE
Allow zpl_preview Access Regardless of Label Template ENV Status  [SCI-9025]

### DIFF
--- a/app/controllers/label_templates_controller.rb
+++ b/app/controllers/label_templates_controller.rb
@@ -4,7 +4,7 @@ class LabelTemplatesController < ApplicationController
   include InputSanitizeHelper
   include TeamsHelper
 
-  before_action :check_feature_enabled, except: :index
+  before_action :check_feature_enabled, except: %i(index zpl_preview)
   before_action :load_label_templates, only: %i(index datatable)
   before_action :load_label_template, only: %i(show set_default update template_tags)
   before_action :check_view_permissions, except: %i(create duplicate set_default delete update)


### PR DESCRIPTION
Jira ticket: [SCI-9025](https://scinote.atlassian.net/browse/SCI-9025)

### What was done
- allow zpl_preview Access Regardless of Label Template ENV Status

[SCI-9025]: https://scinote.atlassian.net/browse/SCI-9025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ