### PR TITLE
Remove bootstrap_form_tag [SCI-9039]

### DIFF
--- a/app/views/users/settings/teams/_destroy_modal.html.erb
+++ b/app/views/users/settings/teams/_destroy_modal.html.erb
@@ -13,7 +13,7 @@
         <%= t("users.settings.teams.edit.modal_destroy_team.message", team: team.name) %>
       </div>
       <div class="modal-footer">
-        <%= bootstrap_form_tag url: destroy_team_path(team), method: :delete do |f| %>
+        <%= form_with url: destroy_team_path(team), method: :delete do |f| %>
           <button type="button" class="btn btn-secondary" data-dismiss="modal"><%= t('general.cancel') %></button>
           <%= f.submit t("users.settings.teams.edit.modal_destroy_team.confirm"), class: "btn btn-danger" %>
         <% end %>


### PR DESCRIPTION
Jira ticket: [SCI-9039](https://scinote.atlassian.net/browse/SCI-9039)

### What was done
- Replace bootstrap_form_tag with form_with at _destroy_modal.html.erb

[SCI-9039]: https://scinote.atlassian.net/browse/SCI-9039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ