### PR TITLE
Non team owner user does not have access to archive inventory [SCI-8995]

### DIFF
--- a/app/views/repositories/_view_archived_btn.html.erb
+++ b/app/views/repositories/_view_archived_btn.html.erb
@@ -1,5 +1,4 @@
-<div class="content-pane flexible <%= params[:archived] ? :archived : :active %> repositories-index"
-      data-readonly="<%= !can_manage_team?(current_team) %>">
+<div class="content-pane flexible <%= params[:archived] ? :archived : :active %> repositories-index">
   <div class="content-header">
     <div class="title-row">
       <h1 data-view-mode="active"><%= t('libraries.index.head_title') %></h1>


### PR DESCRIPTION
Jira ticket: [SCI-8955](https://scinote.atlassian.net/browse/SCI-8955)

### What was done
_added ability for non team owner users to view state switch button for inventories_


[SCI-8955]: https://scinote.atlassian.net/browse/SCI-8955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ