### PR TITLE
Smart annotation modal- inventories are out of modal [SCI-9001]

### DIFF
--- a/app/views/shared/smart_annotation/_menu.html.erb
+++ b/app/views/shared/smart_annotation/_menu.html.erb
@@ -12,7 +12,7 @@
     <div class="tab-pane" role="tabpanel" id="exp-tab-<%= at_who_key %>" data-object-type="EXPERIMENT"></div>
     <div class="tab-pane" role="tabpanel" id="tsk-tab-<%= at_who_key %>" data-object-type="TASK"></div>
     <div class="tab-pane rep-tab" role="tabpanel" id="rep-tab-<%= at_who_key %>" data-object-type="REPOSITORY"><% if repositories.length > 1 %>
-      <div class=sci-btn-group>
+      <div class="sci-btn-group flex-wrap">
       <% repositories.each do |repository| %>
         <button class="btn btn-light repository-object" data-object-id="<%= repository.id %>">
           <% if repository.shared_with?(current_team) %>


### PR DESCRIPTION
Jira ticket: [SCI-9001](https://scinote.atlassian.net/browse/SCI-9001)

### What was done
_fixed styling for inventories inside smart annotation modal_


[SCI-9001]: https://scinote.atlassian.net/browse/SCI-9001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ