### PR TITLE
Add space after (A) in shareable links layout [SCI-9042]

### DIFF
--- a/app/views/shareable_links/my_module_protocol_show.html.erb
+++ b/app/views/shareable_links/my_module_protocol_show.html.erb
@@ -1,5 +1,5 @@
 <div class="text-3xl font-semibold flex flex-row flex-nowrap">
-  <span class="inline-block whitespace-nowrap">
+  <span class="inline-block whitespace-nowrap mr-1">
     <%= t "labels.archived" if @my_module.archived? %>
   </span>
   <span class="inline-block truncate w-[calc(100vw-27rem)]" title="<%= @my_module.name %>">


### PR DESCRIPTION
Jira ticket: [SCI-9042](https://scinote.atlassian.net/browse/SCI-9042)

### What was done
Add space after (A) in shareable links layout 

[SCI-9042]: https://scinote.atlassian.net/browse/SCI-9042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ