### PR TITLE
Add can_create_step_comments to step permissions on Mobile API [SCI-9030]

### DIFF
--- a/app/permissions/step.rb
+++ b/app/permissions/step.rb
@@ -8,4 +8,12 @@ Canaid::Permissions.register_for(Step) do
       can_manage_protocol_in_repository?(user, step.protocol)
     end
   end
+
+  can :create_step_comments do |user, step|
+    if step.my_module
+      can_create_comments_in_my_module_steps(user, step.my_module)
+    else
+      can_manage_protocol_in_repository?(user, step.protocol)
+    end
+  end
 end


### PR DESCRIPTION
Jira ticket: [SCI-9030](https://scinote.atlassian.net/browse/SCI-9030)

### What was done
_added step comment create permission for mobile api_


[SCI-9030]: https://scinote.atlassian.net/browse/SCI-9030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ