### PR TITLE
Fix calls of user assignment propagation jobs with optional assigned_by [SCI-9053]

### DIFF
--- a/app/jobs/user_assignments/project_group_assignment_job.rb
+++ b/app/jobs/user_assignments/project_group_assignment_job.rb
@@ -29,7 +29,7 @@ module UserAssignments
             project,
             user.id,
             project.default_public_user_role || UserRole.find_predefined_viewer_role,
-            @assigned_by.id
+            @assigned_by&.id
           )
         end
       end

--- a/app/services/user_assignments/create_team_user_assignments_service.rb
+++ b/app/services/user_assignments/create_team_user_assignments_service.rb
@@ -24,7 +24,7 @@ module UserAssignments
         UserAssignments::ProjectGroupAssignmentJob.perform_later(
           @team,
           project,
-          @assigned_by.id
+          @assigned_by&.id
         )
       end
     end


### PR DESCRIPTION
Jira ticket: [SCI-9053](https://scinote.atlassian.net/browse/SCI-9053)

### What was done
Fix calls of user assignment propagation jobs with optional assigned_by

[SCI-9053]: https://scinote.atlassian.net/browse/SCI-9053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ