### PR TITLE
Hide welcome modal after initial page load shareable links [SCI-9078]

### DIFF
--- a/app/assets/javascripts/shareable_links/my_module_protocol_show.js
+++ b/app/assets/javascripts/shareable_links/my_module_protocol_show.js
@@ -61,7 +61,7 @@
   }
 
   function initMyModuleProtocolShow() {
-    const myModule = $('#details-container').attr('data-my-module');
+    const myModule = $('#details-container').attr('data-shareable-link');
     if (!sessionStorage.getItem(`my_module_shareable_link_${myModule}`)) {
       sessionStorage.setItem(`my_module_shareable_link_${myModule}`, myModule);
       initWelcomeModal();

--- a/app/assets/javascripts/shareable_links/my_module_protocol_show.js
+++ b/app/assets/javascripts/shareable_links/my_module_protocol_show.js
@@ -61,7 +61,11 @@
   }
 
   function initMyModuleProtocolShow() {
-    initWelcomeModal();
+    const myModule = $('#details-container').attr('data-my-module');
+    if (!sessionStorage.getItem(`my_module_shareable_link_${myModule}`)) {
+      sessionStorage.setItem(`my_module_shareable_link_${myModule}`, myModule);
+      initWelcomeModal();
+    }
     initStepsExpandCollapse();
     initStepComments();
     initStepAttachments();

--- a/app/views/shareable_links/my_module_protocol_show.html.erb
+++ b/app/views/shareable_links/my_module_protocol_show.html.erb
@@ -31,7 +31,7 @@
           </span>
         </div>
       </div>
-      <div id="details-container" class="task-details" data-my-module=<%= @my_module.id %>>
+      <div id="details-container" class="task-details" data-shareable-link=<%= @shareable_link.uuid %>>
         <%= render partial: 'shareable_links/my_modules/my_module_details' %>
       </div>
     </div>

--- a/app/views/shareable_links/my_module_protocol_show.html.erb
+++ b/app/views/shareable_links/my_module_protocol_show.html.erb
@@ -31,7 +31,7 @@
           </span>
         </div>
       </div>
-      <div id="details-container" class="task-details">
+      <div id="details-container" class="task-details" data-my-module=<%= @my_module.id %>>
         <%= render partial: 'shareable_links/my_modules/my_module_details' %>
       </div>
     </div>

--- a/app/views/shareable_links/my_modules/_welcome_modal.html.erb
+++ b/app/views/shareable_links/my_modules/_welcome_modal.html.erb
@@ -1,4 +1,4 @@
-<div class="modal in centered-modal" id="shareable-link-welcome-modal" tabindex="-1" role="dialog" aria-labelledby="shareable-link-welcome-modal-label">
+<div class="modal centered-modal" id="shareable-link-welcome-modal" tabindex="-1" role="dialog" aria-labelledby="shareable-link-welcome-modal-label">
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">


### PR DESCRIPTION
Jira ticket: [SCI-9078](https://scinote.atlassian.net/browse/SCI-9078)

### What was done
_Hide welcome modal using sessionStorage after initial page load of shared link_

#### ToDo:
_N/A_

### Note:
_N/A_


[SCI-9078]: https://scinote.atlassian.net/browse/SCI-9078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ