### PR TITLE
Add .btn-not-started to task status flow modal [SCI-9007]

### DIFF
--- a/app/assets/stylesheets/my_modules/status_flow.scss
+++ b/app/assets/stylesheets/my_modules/status_flow.scss
@@ -137,6 +137,11 @@
         line-height: 1em;
         padding: .5em;
         white-space: nowrap;
+
+        &.btn-not-started {
+          border: 1px solid var(--sn-sleepy-grey);
+          color: var(--sn-black);
+        }
       }
 
       .status-comment {

--- a/app/views/my_modules/modals/_status_flow_modal_body.html.erb
+++ b/app/views/my_modules/modals/_status_flow_modal_body.html.erb
@@ -11,7 +11,8 @@
           <%= t('my_modules.modals.status_flow_modal.current_status') %><i class="fas fa-long-arrow-alt-right"></i>
         <% end %>
       </div>
-      <div class="status-block" style="background: <%= status[:color] %>">
+      <div class="status-block <%= 'btn-not-started' if status.name == 'Not started' %>"
+        style="background: <%= status[:color] %>">
         <%= status[:name] %>
       </div>
       <div class="status-comment">


### PR DESCRIPTION
Jira ticket: [SCI-9007](https://scinote.atlassian.net/browse/SCI-9007)

### What was done
- add css styling to 'Not started' in task status flow modal

[SCI-9007]: https://scinote.atlassian.net/browse/SCI-9007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ