### PR TITLE
Fix TinyMCE help plugin language inclusion [SCI-9086]

### DIFF
--- a/app/javascript/packs/tiny_mce.js
+++ b/app/javascript/packs/tiny_mce.js
@@ -25,6 +25,7 @@ import 'tinymce/plugins/insertdatetime';
 import 'tinymce/plugins/nonbreaking';
 import 'tinymce/plugins/save';
 import 'tinymce/plugins/help';
+import 'tinymce/plugins/help/js/i18n/keynav/en';
 import 'tinymce/plugins/quickbars';
 import 'tinymce/plugins/directionality';
 import './tinymce/custom_image_uploader/plugin';


### PR DESCRIPTION
Jira ticket: [SCI-9086](https://scinote.atlassian.net/browse/SCI-9086)

### What was done
Fix TinyMCE help plugin language inclusion.

Issue mentioned on TinyMCE repository: [https://github.com/tinymce/tinymce/issues/8844](https://github.com/tinymce/tinymce/issues/8844)

[SCI-9086]: https://scinote.atlassian.net/browse/SCI-9086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ