### PR TITLE
Fix 'Not started' status button at missing locations [SCI-9007]

### DIFF
--- a/app/assets/javascripts/experiments/table.js
+++ b/app/assets/javascripts/experiments/table.js
@@ -43,7 +43,8 @@ var ExperimnetTable = {
       return `<a href="${data.url}">${data.count}</a>`;
     },
     status: function(data) {
-      return `<div class="my-module-status" style="background-color: ${data.color}">${data.name}</div>`;
+      return `<div class="my-module-status ${data.name === 'Not started' ? 'btn-not-started' : ''}" 
+        style="background-color: ${data.color}">${data.name}</div>`;
     },
     assigned: function(data) {
       return data.html;

--- a/app/assets/stylesheets/dashboard/current_tasks.scss
+++ b/app/assets/stylesheets/dashboard/current_tasks.scss
@@ -211,6 +211,10 @@
           color: $color-white;
           font-weight: bold;
           padding: .25em .5em;
+
+          &.btn-not-started {
+            @include not-started;
+          }
         }
       }
 

--- a/app/assets/stylesheets/experiment/canvas.scss
+++ b/app/assets/stylesheets/experiment/canvas.scss
@@ -35,6 +35,10 @@
       padding: 2px 8px;
       text-overflow: ellipsis;
       white-space: nowrap;
+
+      &.btn-not-started {
+        @include not-started;
+      }
     }
   }
 

--- a/app/assets/stylesheets/experiment/table.scss
+++ b/app/assets/stylesheets/experiment/table.scss
@@ -359,6 +359,10 @@
       padding: 2px 8px;
       text-overflow: ellipsis;
       white-space: nowrap;
+
+      &.btn-not-started {
+        @include not-started;
+      }
     }
 
     .table-row-placeholder-divider {

--- a/app/assets/stylesheets/mixins.scss
+++ b/app/assets/stylesheets/mixins.scss
@@ -77,6 +77,10 @@
   width: .5em;
 }
 
+@mixin not-started {
+  border: 1px solid var(--sn-sleepy-grey);
+  color: var(--sn-black);
+}
 
 // Material design mixins
 

--- a/app/assets/stylesheets/my_modules/status_flow.scss
+++ b/app/assets/stylesheets/my_modules/status_flow.scss
@@ -13,8 +13,7 @@
       width: 100%;
 
       &.btn-not-started {
-        border: 1px solid var(--sn-sleepy-grey);
-        color: var(--sn-black);
+        @include not-started;
       }
 
       .caret {
@@ -74,8 +73,7 @@
       }
 
       .btn-not-started {
-        border: 1px solid var(--sn-sleepy-grey);
-        color: var(--sn-black);
+        @include not-started;
       }
 
       .error-message {
@@ -139,8 +137,7 @@
         white-space: nowrap;
 
         &.btn-not-started {
-          border: 1px solid var(--sn-sleepy-grey);
-          color: var(--sn-black);
+          @include not-started;
         }
       }
 

--- a/app/views/canvas/full_zoom/_my_module.html.erb
+++ b/app/views/canvas/full_zoom/_my_module.html.erb
@@ -65,12 +65,13 @@
       </div>
     </div>
 
-    <div class="status-label" style="--state-color: <%= my_module.my_module_status.color %>">
-      <% if my_module.status_changing %>
-        <i class="fas fa-spinner fa-spin"></i>
-        <span><%= t('experiments.canvas.full_zoom.status_transitioning_label') %></span>
-      <% end %>
-      <%= my_module.my_module_status.name %>
+    <div class="status-label <%= 'btn-not-started' if my_module.my_module_status.name == 'Not started' %>"
+      style="--state-color: <%= my_module.my_module_status.color %>">
+        <% if my_module.status_changing %>
+          <i class="fas fa-spinner fa-spin"></i>
+          <span><%= t('experiments.canvas.full_zoom.status_transitioning_label') %></span>
+        <% end %>
+        <%= my_module.my_module_status.name %>
     </div>
   </div>
 

--- a/app/views/dashboards/current_tasks/_task.html.erb
+++ b/app/views/dashboards/current_tasks/_task.html.erb
@@ -16,6 +16,9 @@
     <% end %>
   </div>
   <div class="task-status-container row-border">
-    <span class="task-status" style="background:<%= task.status_color %>"><%= task.status_name %></span>
+    <span class="task-status <%= 'btn-not-started' if task.status_name == 'Not started' %>"
+      style="background:<%= task.status_color %>">
+        <%= task.status_name %>
+    </span>
   </div>
 </a>


### PR DESCRIPTION
Jira ticket: [SCI-9007](https://scinote.atlassian.net/browse/SCI-9007)

### What was done
- add css mixin for status button 'Not started'
- conditionally add the class at missing locations


[SCI-9007]: https://scinote.atlassian.net/browse/SCI-9007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ