### PR TITLE
Hide Cancel/Save btns after click at Share task modal [SCI-9008]

### DIFF
--- a/app/javascript/vue/shareable_links/components/shareable_link_modal.vue
+++ b/app/javascript/vue/shareable_links/components/shareable_link_modal.vue
@@ -177,11 +177,13 @@
           success: (result) => {
             this.shareableData = result.data;
             this.dirty = false;
+            this.editing = false;
           }
         });
       },
       cancelDescriptionEdit() {
         this.description = this.shareableData.attributes.description || '';
+        this.editing = false;
       },
       initCharacterCount() {
         $(this.$refs.textarea).on('input change paste keydown', () => {


### PR DESCRIPTION
Jira ticket: [SCI-9008](https://scinote.atlassian.net/browse/SCI-9008)

### What was done
- hide Cancel/Save buttons after clicking them at Share task modal 

[SCI-9008]: https://scinote.atlassian.net/browse/SCI-9008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ