### PR TITLE
Add bootstrap-select to experiment clone modal and fix overflowing text [SCI-8559]

### DIFF
--- a/app/assets/javascripts/label_templates/label_templates_datatable.js
+++ b/app/assets/javascripts/label_templates/label_templates_datatable.js
@@ -259,6 +259,10 @@
         targets: 2,
         className: 'label-template-name',
         render: renderNameHTML
+      }, {
+        targets: 4,
+        className: 'whitespace-break-spaces',
+        render: data => `<span class='whitespace-break-spaces'>${data}</span>`
       }],
       oLanguage: {
         sSearch: I18n.t('general.filter')

--- a/app/assets/stylesheets/dashboard/create_task_modal.scss
+++ b/app/assets/stylesheets/dashboard/create_task_modal.scss
@@ -35,9 +35,11 @@
       }
 
       .dropdown-option {
-        overflow: hidden;
-        text-overflow: clip;
-        white-space: nowrap;
+        &[data-value = '0'] {
+          overflow: hidden;
+          text-overflow: clip;
+          white-space: nowrap;
+        }
       }
     }
 

--- a/app/assets/stylesheets/experiments.scss
+++ b/app/assets/stylesheets/experiments.scss
@@ -13,8 +13,6 @@
   }
 
   .dropdown-menu {
-    width: 328px;
-
     .dropdown-item {
       min-height: 32px;
       outline: none;

--- a/app/assets/stylesheets/experiments.scss
+++ b/app/assets/stylesheets/experiments.scss
@@ -5,6 +5,23 @@
 
 
 // New experiments page
+.clone-experiment-modal,
+.move-experiment-modal {
+  .dropdown-toggle {
+    box-shadow: unset;
+    outline: unset;
+  }
+
+  .dropdown-menu {
+    width: 328px;
+
+    .dropdown-item {
+      min-height: 32px;
+      outline: none;
+      white-space: break-spaces;
+    }
+  }
+}
 
 .projects-show {
   .content-header {

--- a/app/views/experiments/_clone_modal.html.erb
+++ b/app/views/experiments/_clone_modal.html.erb
@@ -1,4 +1,4 @@
-<div class="modal" id="clone-experiment-modal-<%= @experiment.id %>" tabindex="-1" role="dialog" aria-labelledby="clone-experiment-modal-label">
+<div class="modal clone-experiment-modal" id="clone-experiment-modal-<%= @experiment.id %>" tabindex="-1" role="dialog" aria-labelledby="clone-experiment-modal-label">
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <%= form_with model: @experiment, url: clone_experiment_path(@experiment, :view_mode=>view_mode), method: :post do |f| %>
@@ -17,7 +17,7 @@
                            end
                          end,
                          @experiment.project.id ),
-                       {}, {"data-role" => "clear"} %>
+                       {}, { class: "form-control selectpicker", "data-role" => "clear" } %>
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" data-dismiss="modal"><%=t "general.cancel" %></button>


### PR DESCRIPTION

Jira ticket: [SCI-8995](https://scinote.atlassian.net/browse/SCI-8995)

### What was done
_Add bootstrap-select to experiment clone modal and fix overflowing text_

#### ToDo:
_N/A_

### Note:
_N/A_


[SCI-8995]: https://scinote.atlassian.net/browse/SCI-8995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ