### PR TITLE
Remove obsolete JS code inclusion from protocol_status_bar [SCI-9134]

### DIFF
--- a/app/assets/javascripts/my_modules/protocols/protocol_status_bar.js
+++ b/app/assets/javascripts/my_modules/protocols/protocol_status_bar.js
@@ -1,7 +1,0 @@
-$(function() {
-  $('body').tooltip({ selector: '[data-toggle=tooltip]' });
-});
-
-$(function() {
-  $('[data-toggle="popover"]').popover();
-});

--- a/app/views/my_modules/protocols/_protocol_status_bar.html.erb
+++ b/app/views/my_modules/protocols/_protocol_status_bar.html.erb
@@ -68,4 +68,3 @@
       </div>
     </div>
 </div>
-<%= javascript_include_tag("my_modules/protocols/protocol_status_bar") %>


### PR DESCRIPTION
Jira ticket: [SCI-9134](https://scinote.atlassian.net/browse/SCI-9134)

### What was done
Remove obsolete JS code inclusion from protocol_status_bar

[SCI-9134]: https://scinote.atlassian.net/browse/SCI-9134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ