### PR TITLE
Fix label templates datatables height overflow [SCI-8559]

### DIFF
--- a/app/assets/stylesheets/label_templates/index.scss
+++ b/app/assets/stylesheets/label_templates/index.scss
@@ -59,7 +59,7 @@
 }
 
 .label-templates-datatable {
-  --content-header-size: 3.5rem;
+  --content-header-size: 4.5rem;
   height: calc(100vh - var(--top-navigation-height) - var(--breadcrumbs-navigation-height) - var(--content-header-size));
 
   #label-templates-table_wrapper {
@@ -72,7 +72,7 @@
       display: flex;
       flex-direction: column;
       flex-grow: 1;
-      height: calc(100% - var(--datatable-pagination-row) - 3.5rem);
+      height: calc(100% - var(--datatable-pagination-row) - 4.5rem);
 
       .dataTables_scrollHead {
         flex-shrink: 0;


### PR DESCRIPTION
Jira ticket: [SCI-8559](https://scinote.atlassian.net/browse/SCI-8559)

### What was done
_Fix label templates datatables height overflow_

#### ToDo:
_N/A_

### Note:
_N/A_


[SCI-8559]: https://scinote.atlassian.net/browse/SCI-8559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ