### PR TITLE
Fix description text area when creating a new team [SCI-9138]

### DIFF
--- a/app/views/users/settings/teams/new.html.erb
+++ b/app/views/users/settings/teams/new.html.erb
@@ -6,19 +6,20 @@
   <div class="tab-pane content-pane" role="tabpanel"></div>
   <div class="tab-pane content-pane active" role="tabpanel">
     <%= form_with model: @new_team, url: create_team_path do |f| %>
-      <div class="form-group sci-input-container" style="max-width: 500px;">
+      <div class="sci-input-container mb-4 max-w-lg" style="display: block !important">
         <label><%= t('users.settings.teams.new.name_label') %></label>
         <%= f.text_field :name,
                          autofocus: true,
                          class: 'sci-input-field',
                          placeholder: t('users.settings.teams.new.name_placeholder') %>
+        <br>
         <small>
           <%=t 'users.settings.teams.new.name_sublabel' %>
         </small>
       </div>
 
-      <div class="form-group" style="max-width: 500px;">
-        <%= f.text_area :description, label: t('users.settings.teams.new.description_label') %>
+      <div class="sci-input-container mb-4 max-w-lg" style="display: block !important">
+        <%= f.text_area :description, class: "sci-input-field textarea", label: t('users.settings.teams.new.description_label') %>
         <br>
         <small>
           <%=t 'users.settings.teams.new.description_sublabel' %>


### PR DESCRIPTION
Jira ticket: [SCI-9138](https://scinote.atlassian.net/browse/SCI-9138)

### What was done
Fix the description text area when creating a new team

[SCI-9138]: https://scinote.atlassian.net/browse/SCI-9138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ