### PR TITLE
Add .json extension to OVE import tooltip [SCI-9116]

### DIFF
--- a/app/javascript/vue/ove/OpenVectorEditor.vue
+++ b/app/javascript/vue/ove/OpenVectorEditor.vue
@@ -63,7 +63,25 @@
         onSave: this.saveFile,
         generatePng: true,
         readOnly: this.readOnly,
-        showMenuBar: true
+        showMenuBar: true,
+        ToolBarProps: {
+          toolList: [
+            'saveTool',
+            'downloadTool',
+            { name: 'importTool', tooltip: I18n.t('open_vector_editor.editor.tooltips.importTool') },
+            'undoTool',
+            'redoTool',
+            'cutsiteTool',
+            'featureTool',
+            'partTool',
+            'oligoTool',
+            'orfTool',
+            'alignmentTool',
+            'editTool',
+            'findTool',
+            'visibilityTool'
+          ]
+        }
       }
 
       if (this.readOnly) {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3711,6 +3711,9 @@ en:
       bullet_2: "Visualize"
       bullet_3: "Annotate"
       button: "Try Sequence editor"
+    editor:
+      tooltips:
+        importTool: "Click or drag to import and view files (.fasta .gb .dna .json)"
   pdf_preview:
     fit_to_screen: 'Fit to screen'
     pages:


### PR DESCRIPTION
Jira ticket: [SCI-9116](https://scinote.atlassian.net/browse/SCI-9116)

### What was done
_Add .json extension to OVE import tooltip_

#### ToDo:
_N/A_

### Note:
_N/A_


[SCI-9116]: https://scinote.atlassian.net/browse/SCI-9116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ