### PR TITLE
Hide align toolbar option in OVE editor [SCI-9113]

### DIFF
--- a/app/javascript/vue/ove/OpenVectorEditor.vue
+++ b/app/javascript/vue/ove/OpenVectorEditor.vue
@@ -76,7 +76,8 @@
             'partTool',
             'oligoTool',
             'orfTool',
-            'alignmentTool',
+            // Hide allignment tool
+            // 'alignmentTool',
             'editTool',
             'findTool',
             'visibilityTool'


### PR DESCRIPTION
Jira ticket: [SCI-9113](https://scinote.atlassian.net/browse/SCI-9113)

### What was done
_Hide align toolbar option in OVE editor_

#### ToDo:
_N/A_

### Note:
_N/A_


[SCI-9113]: https://scinote.atlassian.net/browse/SCI-9113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ