### PR TITLE
Button translation in the "Move to different result" Modal [sci-9186]

### DIFF
--- a/app/javascript/vue/shared/content/modal/move.vue
+++ b/app/javascript/vue/shared/content/modal/move.vue
@@ -23,7 +23,7 @@
         </div>
         <div class="modal-footer">
           <button class="btn btn-secondary" @click="cancel">{{ i18n.t('general.cancel') }}</button>
-          <button class="btn btn-primary" @click="confirm">{{ i18n.t('general.save')}}</button>
+          <button class="btn btn-primary" @click="confirm">{{ i18n.t('general.move')}}</button>
         </div>
       </div>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3534,6 +3534,7 @@ en:
     newer_version_available: "Newer version of the text below has been saved in the browser. Do you want to restore it?"
   general:
     save: "Save"
+    move: "Move"
     update: "Update"
     edit: "Edit"
     delete: "Delete"


### PR DESCRIPTION
Jira ticket: [SCI-9186](https://scinote.atlassian.net/browse/SCI-9186)

### What was done
_changed modal success button's translationt_


[SCI-9186]: https://scinote.atlassian.net/browse/SCI-9186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ