### PR TITLE
Fix my_module_results_path and add id to experiments/tablejs tag [SCI-9111]

### DIFF
--- a/app/services/experiments/table_view_service.rb
+++ b/app/services/experiments/table_view_service.rb
@@ -147,7 +147,7 @@ module Experiments
     def results_presenter(my_module)
       {
         count: (my_module.archived_branch? ? my_module.results : my_module.results.active).length,
-        url: results_my_module_path(my_module)
+        url: my_module_results_path(my_module)
       }
     end
 

--- a/app/views/experiments/table.html.erb
+++ b/app/views/experiments/table.html.erb
@@ -66,5 +66,5 @@
 
 <%= javascript_include_tag "vue_components_action_toolbar" %>
 <%= javascript_include_tag("my_modules/tags") %>
-<%= javascript_include_tag("experiments/table") %>
+<%= javascript_include_tag("experiments/table", id: "experiments-table-js-tag") %>
 <%= javascript_include_tag("experiments/dropdown_actions") %>


### PR DESCRIPTION
Jira ticket: [SCI-9111](https://scinote.atlassian.net/browse/SCI-9111)

### What was done
- fix my_module_results_path and add id to experiments/tablejs tag


[SCI-9111]: https://scinote.atlassian.net/browse/SCI-9111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ