### PR TITLE
Don't display icons in fields with errors (alignment issues) [SCI-9217]

### DIFF
--- a/app/assets/stylesheets/shared/form_errors.scss
+++ b/app/assets/stylesheets/shared/form_errors.scss
@@ -9,7 +9,7 @@
 .form-group.has-error {
   margin-bottom: 0;
 
-  .form-control {
-    height: auto;
+  .sn-icon {
+    display: none;
   }
 }


### PR DESCRIPTION
Jira ticket: [SCI-9217](https://scinote.atlassian.net/browse/SCI-9217)

### What was done
Don't display icons in fields with errors (alignment issues)

[SCI-9217]: https://scinote.atlassian.net/browse/SCI-9217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ