### PR TITLE
Allow non-automatic user_assignments to be updated when user role is changed [SCI-9173]

### DIFF
--- a/app/services/user_assignments/update_team_user_assignments_service.rb
+++ b/app/services/user_assignments/update_team_user_assignments_service.rb
@@ -17,11 +17,11 @@ module UserAssignments
 
     def update_repositories_assignments
       @team.repositories
-           .joins(:automatic_user_assignments)
-           .preload(:automatic_user_assignments)
-           .where(automatic_user_assignments: { user: @user, team: @team })
+           .joins(:user_assignments)
+           .preload(:user_assignments)
+           .where(user_assignments: { user: @user, team: @team })
            .find_each do |repository|
-        repository.automatic_user_assignments
+        repository.user_assignments
                   .select { |assignment| assignment[:user_id] == @user.id && assignment[:team_id] == @team.id }
                   .each { |assignment| assignment.update!(user_role: @user_role) }
       end


### PR DESCRIPTION
Jira ticket: [SCI-9173](https://scinote.atlassian.net/browse/SCI-9173)

### What was done
_Allow non-automatic user_assignments to be updated when the user role is changed_

#### ToDo:
_N/A_

### Note:
_N/A_


[SCI-9173]: https://scinote.atlassian.net/browse/SCI-9173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ