### PR TITLE
Fix missing OVE file preview [SCI-9214]

### DIFF
--- a/app/javascript/vue/protocol/step_attachments/thumbnail.vue
+++ b/app/javascript/vue/protocol/step_attachments/thumbnail.vue
@@ -16,7 +16,7 @@
             @error="ActiveStoragePreviews.reCheckPreview"
             @load="ActiveStoragePreviews.showPreview"
             style='opacity: 0' />
-        <i  v-else class="fas" :class="attachment.attributes.icon"></i>
+        <span v-else class="sn-icon sn-icon-sequence-editor"></span>
       </div>
       <div class="attachment-label"
            data-toggle="tooltip"

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -226,6 +226,18 @@ class Asset < ApplicationRecord
       to_blob = ActiveStorage::Blob.create_and_upload!(io: tmp_file, filename: blob.filename, metadata: blob.metadata)
       to_asset.file.attach(to_blob)
     end
+
+    if preview_image.attached?
+      preview_image.blob.open do |tmp_preview_image|
+        to_blob = ActiveStorage::Blob.create_and_upload!(
+          io: tmp_preview_image,
+          filename: blob.filename,
+          metadata: blob.metadata
+        )
+        to_asset.preview_image.attach(to_blob)
+      end
+    end
+
     to_asset.post_process_file(to_asset.team)
   end
 


### PR DESCRIPTION
Jira ticket: [SCI-9214](https://scinote.atlassian.net/browse/SCI-9214)

### What was done
Fixed duplicate_file method in asset.rb to also attach preview_image. Also changed thumbnail.vue to use latest icon as fallback.


[SCI-9214]: https://scinote.atlassian.net/browse/SCI-9214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ