### PR TITLE
Fix missing paperclip icon for file attachment [SCI-9224]

### DIFF
--- a/app/javascript/vue/protocol/step_attachments/thumbnail.vue
+++ b/app/javascript/vue/protocol/step_attachments/thumbnail.vue
@@ -10,13 +10,15 @@
         :data-gallery-view-id="stepId"
         :data-preview-url="attachment.attributes.urls.preview"
     >
-      <div class="attachment-preview" :class= "attachment.attributes.asset_type">
-        <img v-if="attachment.attributes.medium_preview"
+      <div v-if="attachment.attributes.medium_preview" class="attachment-preview" :class= "attachment.attributes.asset_type">
+        <img
             :src="attachment.attributes.medium_preview"
             @error="ActiveStoragePreviews.reCheckPreview"
             @load="ActiveStoragePreviews.showPreview"
             style='opacity: 0' />
-        <span v-else class="sn-icon sn-icon-sequence-editor"></span>
+      </div>
+      <div v-else class="attachment-preview flex">
+        <span class="fa fa-paperclip m-auto text-4xl"></span>
       </div>
       <div class="attachment-label"
            data-toggle="tooltip"


### PR DESCRIPTION
Jira ticket: [SCI-9224](https://scinote.atlassian.net/browse/SCI-9224)

### What was done
Changed logic to use fa-paperclip as fallback for files that don't generate a preview. Added appropriate tailwind classes for proper styling.

[SCI-9224]: https://scinote.atlassian.net/browse/SCI-9224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ