### PR TITLE
Fix wrong OVE file size [SCI-9243]

### DIFF
--- a/app/controllers/gene_sequence_assets_controller.rb
+++ b/app/controllers/gene_sequence_assets_controller.rb
@@ -65,6 +65,8 @@ class GeneSequenceAssetsController < ApplicationController
       file.blob.metadata['name'] = params[:sequence_name]
       file.save!
 
+      @asset.view_mode = @parent.assets_view_mode
+
       @asset.save!
     end
   end


### PR DESCRIPTION
Jira ticket: [SCI-9243](https://scinote.atlassian.net/browse/SCI-9243)

### What was done
Fixed issue with newly created files defaulting to 'thumbnail' size.
Needed to add additional logic in the gene_sequence_assets_controller.rb for asset to use its parent's assets_view_mode.


[SCI-9243]: https://scinote.atlassian.net/browse/SCI-9243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ