### PR TITLE
Protocol template title is displayed in the grey area [SCI-9237]

### DIFF
--- a/app/views/protocols/show.html.erb
+++ b/app/views/protocols/show.html.erb
@@ -3,7 +3,6 @@
   <%= render partial: "/shared/sidebar/templates_sidebar", locals: {active: :protocol} %>
 <% end %>
  <% provide(:container_class, 'no-second-nav-container') %>
-<div class="content-pane protocols-show flexible" >
   <div class="content-header">
     <div class="title-row">
       <h1>
@@ -28,6 +27,7 @@
       </h1>
     </div>
   </div>
+<div class="content-pane protocols-show flexible" >
   <div class="protocol-position-container">
     <div
       id="protocolContainer"


### PR DESCRIPTION
Jira ticket: [SCI-9237](https://scinote.atlassian.net/browse/SCI-9237)

### What was done
_fixed protocol title placing_


[SCI-9237]: https://scinote.atlassian.net/browse/SCI-9237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ