### PR TITLE
Keep asset image tooltip aspect ratio [SCI-9277]

### DIFF
--- a/app/assets/stylesheets/shared/assets.scss
+++ b/app/assets/stylesheets/shared/assets.scss
@@ -272,7 +272,6 @@
 
     img {
       height: 150px;
-      width: 150px;
     }
   }
 


### PR DESCRIPTION
Jira ticket: [SCI-9277](https://scinote.atlassian.net/browse/SCI-9277)

### What was done
Keep asset image tooltip aspect ratio

[SCI-9277]: https://scinote.atlassian.net/browse/SCI-9277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ