### PR TITLE
Disable move button in move content modal if there's no target selected [SCI-9278]

### DIFF
--- a/app/javascript/vue/shared/content/modal/move.vue
+++ b/app/javascript/vue/shared/content/modal/move.vue
@@ -1,5 +1,5 @@
 <template>
-  <div ref="modal" @keydown.esc="cancel" class="modal" id="modalDestroyProtocolContent" tabindex="-1" role="dialog">
+  <div ref="modal" @keydown.esc="cancel" class="modal" id="modalMoveProtocolContent" tabindex="-1" role="dialog">
     <div class="modal-dialog" role="document">
       <div class="modal-content">
         <div class="modal-header">
@@ -38,7 +38,7 @@
         </div>
         <div class="modal-footer">
           <button class="btn btn-secondary" @click="cancel">{{ i18n.t('general.cancel') }}</button>
-          <button class="btn btn-primary" @click="confirm">{{ i18n.t('general.move')}}</button>
+          <button class="btn btn-primary" @click="confirm" :disabled="!target">{{ i18n.t('general.move')}}</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Jira ticket: [SCI-9278](https://scinote.atlassian.net/browse/SCI-9278)

### What was done
Disable move button in move content modal if there's no target selected

[SCI-9278]: https://scinote.atlassian.net/browse/SCI-9278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ