### PR TITLE
Fix no OVE file preview from imported .eln [SCI-9263]

### DIFF
--- a/app/controllers/protocols_controller.rb
+++ b/app/controllers/protocols_controller.rb
@@ -697,6 +697,12 @@ class ProtocolsController < ApplicationController
               asset_file_name = asset_guid.to_s + File.extname(asset.file_name).to_s
               ostream.put_next_entry("#{step_dir}/#{asset_file_name}")
               ostream.print(asset.file.download)
+
+              next unless asset.preview_image.attached?
+
+              asset_preview_image_name = asset_guid.to_s + File.extname(asset.file_name).to_s
+              ostream.put_next_entry("#{step_dir}/previews/#{asset_preview_image_name}")
+              ostream.print(asset.preview_image.download)
             end
           end
           ostream = step.tiny_mce_assets.save_to_eln(ostream, step_dir)


### PR DESCRIPTION
Jira ticket: [SCI-9263](https://scinote.atlassian.net/browse/SCI-9263)

### What was done
Added a preview_image clause in export method of protocols_controller.rb.
Changed newAssetElement and getAssetBytes methods of import.js to correctly parse incoming files.


[SCI-9263]: https://scinote.atlassian.net/browse/SCI-9263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ