### PR TITLE
Fix displaying the 'more' link for multiline experiment description [SCI-9096]

### DIFF
--- a/app/views/projects/show/_experiment_card.html.erb
+++ b/app/views/projects/show/_experiment_card.html.erb
@@ -74,7 +74,7 @@
     <div class="description-text">
       <%= custom_auto_link(experiment.description, team: current_team) %>
     </div>
-    <% if experiment.description.present? && (experiment.description.length > Constants::EXPERIMENT_LONG_DESCRIPTION || experiment.description.count("\n") > 2) %>
+    <% if experiment.description.present? && (experiment.description.length > Constants::EXPERIMENT_LONG_DESCRIPTION || experiment.description.count("\n") > 1) %>
       <%= link_to t('experiments.card.more'),
             experiment_path(experiment),
             class: 'more-button experiment-action-link',


### PR DESCRIPTION


Jira ticket: [SCI-9096](https://scinote.atlassian.net/browse/SCI-9096)

### What was done
Fix displaying the 'more' link for multiline experiment description. It should display if there is more than one line break (3 lines).

[SCI-9096]: https://scinote.atlassian.net/browse/SCI-9096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ