### PR TITLE
Fix dropdown caret placement and name vertical centering for results [SCI-9290]

### DIFF
--- a/app/assets/stylesheets/my_modules/results/index.scss
+++ b/app/assets/stylesheets/my_modules/results/index.scss
@@ -84,23 +84,9 @@
 }
 
 .result-head-left {
-  display: grid;
-  grid-template-columns: 0fr 1fr;
-
   .result-collapse-link {
-    display: inline-block;
-    flex-shrink: 0;
-    line-height: 24px;
-    position: relative;
-    text-align: center;
-    top: 2px;
-    width: 24px;
-
     &:not(.collapsed) {
-      position: relative;
-      right: 5px;
-      top: -3px;
-      transform: rotate(90deg);
+      @include rotate(90deg);
     }
   }
 }

--- a/app/javascript/vue/results/result.vue
+++ b/app/javascript/vue/results/result.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="result-wrapper bg-white px-4 py-2 mb-4">
     <div class="result-header flex justify-between py-2">
-      <div class="result-head-left">
-        <a class="result-collapse-link hover:no-underline focus:no-underline"
+      <div class="result-head-left flex items-center">
+        <a class="result-collapse-link hover:no-underline focus:no-underline flex flex-shrink-0 mr-2"
             :href="'#resultBody' + result.id"
             data-toggle="collapse"
             data-remote="true">


### PR DESCRIPTION
Jira ticket: [SCI-9290](https://scinote.atlassian.net/browse/SCI-9290)

### What was done
- fix dropdown caret placement and name vertical centering for results 

[SCI-9290]: https://scinote.atlassian.net/browse/SCI-9290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ