### PR TITLE
Fix wrong OVE view file size after editing [SCI_9294]

### DIFF
--- a/app/controllers/gene_sequence_assets_controller.rb
+++ b/app/controllers/gene_sequence_assets_controller.rb
@@ -64,9 +64,7 @@ class GeneSequenceAssetsController < ApplicationController
       file.blob.metadata['asset_type'] = 'gene_sequence'
       file.blob.metadata['name'] = params[:sequence_name]
       file.save!
-
-      @asset.view_mode = @parent.assets_view_mode
-
+      @asset.view_mode ||= @parent.assets_view_mode
       @asset.save!
     end
   end


### PR DESCRIPTION
Jira ticket: [SCI-9294](https://scinote.atlassian.net/browse/SCI-9294)

### What was done
Fixed save_asset method in gene_sequence_assets_controller to prioritize asset's view_mode over its parent's


[SCI-9294]: https://scinote.atlassian.net/browse/SCI-9294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ