### PR TITLE
Insert the correct link for protocol parser import in the email notification [SCI-9273]

### DIFF
--- a/app/views/users/mailer/notification.html.erb
+++ b/app/views/users/mailer/notification.html.erb
@@ -21,7 +21,7 @@
   <% if @notification.system_message? %>
     <% # We assume the system notification is clean %>
     <%= @notification.message.html_safe %>
-  <% elsif @notification.deliver? && @notification.message.match?(/data-id=('|")(\d*)('|")/) %>
+  <% elsif @notification.deliver? && @notification.message.match?(/data-id=('|")(\d*)('|")/) && @notification.message.match?(/href=('|")\/zip_exports/) %>
     <%= I18n.t("notifications.deliver.download_link") %>
     <% # work around the problem with inserting the link of zipExport %>
     <% zip_id = /data-id=('|")(\d*)('|")/.match(@notification.message)[2] %>


### PR DESCRIPTION
Jira ticket: [SCI-9273](https://scinote.atlassian.net/browse/SCI-9273)

### What was done
Insert the correct link for protocol parser import in the email notification 

[SCI-9273]: https://scinote.atlassian.net/browse/SCI-9273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ