### PR TITLE
Fix issue displaying long tables protocol description in import modal [SCI-9191]

### DIFF
--- a/app/views/protocols/import_export/_import_modal.html.erb
+++ b/app/views/protocols/import_export/_import_modal.html.erb
@@ -26,7 +26,7 @@
         </div>
         <div class="form-group">
           <label for="import_protocol_description"><%= t("protocols.import_export.import_modal.description_label") %></label>
-          <div id="import_protocol_description" rows="2"></div>
+          <div id="import_protocol_description" class="overflow-auto" rows="2"></div>
         </div>
         <div class="form-group">
           <div class="row">


### PR DESCRIPTION
Jira ticket: [SCI-9191](https://scinote.atlassian.net/browse/SCI-9191)

### What was done
_Fix issue displaying long tables protocol description in import modal_

#### ToDo:
_N/A_

### Note:
_N/A_
