### PR TITLE
Removed delete/edit comment access on archived results [SCI-9289]

### DIFF
--- a/app/permissions/result.rb
+++ b/app/permissions/result.rb
@@ -30,7 +30,7 @@ Canaid::Permissions.register_for(ResultComment) do
   %i(manage_result_comment)
     .each do |perm|
     can perm do |_, comment|
-      !comment.result.my_module.archived_branch?
+      !comment.result.my_module.archived_branch? && comment.result.active?
     end
   end
 


### PR DESCRIPTION
Jira ticket: [SCI-9289](https://scinote.atlassian.net/browse/SCI-9289)

### What was done
_permission changed for archived result comments_


[SCI-9289]: https://scinote.atlassian.net/browse/SCI-9289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ