### PR TITLE
Fix dropdown always open on protocol templates [SCI-9333]

### DIFF
--- a/app/views/protocols/index/_general_toolbar.html.erb
+++ b/app/views/protocols/index/_general_toolbar.html.erb
@@ -18,7 +18,7 @@
           <span class="sn-icon sn-icon-import"></span><span class="hidden-xs"><%= t("protocols.index.import") %></span>
         </button>
 
-        <ul class="dropdown-menu rounded !grid !p-2.5 !gap-y-px sn-shadow-menu-sm">
+        <ul class="dropdown-menu rounded !p-2.5 !gap-y-px sn-shadow-menu-sm">
           <li>
             <a class="btn-open-file !pl-3 !py-2.5 hover:!bg-sn-super-light-blue rounded !text-sn-blue data-action='import'" >
               <span><%= t('protocols.index.import_eln') %></span>


### PR DESCRIPTION
Jira ticket: [SCI-9333](https://scinote.atlassian.net/browse/SCI-9333)

### What was done
- fix dropdown always open on protocol templates 


[SCI-9333]: https://scinote.atlassian.net/browse/SCI-9333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ