### PR TITLE
Fix for downloading assets not in current user team [SCI-9353]

### DIFF
--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -319,6 +319,8 @@ class AssetsController < ApplicationController
     @asset = Asset.find_by(id: params[:id])
     return render_404 unless @asset
 
+    current_user.permission_team = @asset.team
+
     @assoc ||= @asset.step
     @assoc ||= @asset.result
     @assoc ||= @asset.repository_cell


### PR DESCRIPTION
Jira ticket: [SCI-9353](https://scinote.atlassian.net/browse/SCI-9353)

### What was done
Fix for downloading assets not in current user team

[SCI-9353]: https://scinote.atlassian.net/browse/SCI-9353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ