### PR TITLE
Reduce allowed data attributes in sanitizer config only to data-mce-token [SCI-9369]

### DIFF
--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -324,7 +324,7 @@ class Constants
   config = Sanitize::Config::RELAXED.deep_dup
   config[:attributes][:all] << 'id'
   config[:attributes][:all] << 'contenteditable'
-  config[:attributes][:all] << :data
+  config[:attributes]['img'] << 'data-mce-token'
   INPUT_SANITIZE_CONFIG = Sanitize::Config.freeze_config(config)
 
   REPOSITORY_DEFAULT_PAGE_SIZE = 10


### PR DESCRIPTION
Jira ticket: [SCI-9369](https://scinote.atlassian.net/browse/SCI-9369)

### What was done
Reduce allowed data attributes in sanitizer config only to data-mce-token

[SCI-9369]: https://scinote.atlassian.net/browse/SCI-9369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ