### PR TITLE
Fix linked protocol info button position [SCI-9328]

### DIFF
--- a/app/javascript/vue/protocol/container.vue
+++ b/app/javascript/vue/protocol/container.vue
@@ -17,10 +17,10 @@
               </div>
             </a>
           </template>
-        </div>
-        <div :class="{'hidden': headerSticked}">
-          <div class="my-module-protocol-status">
-            <!-- protocol status dropdown gets mounted here -->
+          <div :class="{'hidden': headerSticked}">
+            <div class="my-module-protocol-status">
+              <!-- protocol status dropdown gets mounted here -->
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Jira ticket: [SCI-9328](https://scinote.atlassian.net/browse/SCI-9328)

### What was done
Fix linked protocol info button position

[SCI-9328]: https://scinote.atlassian.net/browse/SCI-9328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ