### PR TITLE
Fix move_targets methods to only return active results; prevent moving elements to archived results [SCI-9403]

### DIFF
--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -71,16 +71,23 @@ class AssetsController < ApplicationController
       render json: { targets: protocol.steps.order(:position).where.not(id: @assoc.id).map { |i| [i.id, i.name] } }
     elsif @assoc.is_a?(Result)
       my_module = @assoc.my_module
-      render json: { targets: my_module.results.where.not(id: @assoc.id).map { |i| [i.id, i.name] } }
+      render json: { targets: my_module.results.active.where.not(id: @assoc.id).map { |i| [i.id, i.name] } }
     else
       render json: { targets: [] }
     end
   end
 
   def move
+    case @assoc
+    when Step
+      target = @assoc.protocol.steps.find_by(id: params[:target_id])
+    when Result
+      target = @assoc.my_module.results.active.find_by(id: params[:target_id])
+      return render_404 unless target
+    end
+
     ActiveRecord::Base.transaction do
       if @assoc.is_a?(Step)
-        target = @assoc.protocol.steps.find_by(id: params[:target_id])
         object_to_update = @asset.step_asset
         object_to_update.update!(step: target)
 
@@ -114,7 +121,6 @@ class AssetsController < ApplicationController
 
         render json: {}
       elsif @assoc.is_a?(Result)
-        target = @assoc.my_module.results.find_by(id: params[:target_id])
         object_to_update = @asset.result_asset
         object_to_update.update!(result: target)
 

--- a/app/controllers/result_elements/base_controller.rb
+++ b/app/controllers/result_elements/base_controller.rb
@@ -6,7 +6,11 @@ module ResultElements
     before_action :check_manage_permissions
 
     def move_targets
-      render json: { targets: @my_module.results.where.not(id: @result.id).map{ |i| [i.id, i.name] } }
+      targets = @my_module.results
+                          .active
+                          .where.not(id: @result.id)
+                          .map { |i| [i.id, i.name] }
+      render json: { targets: targets }
     end
 
     private

--- a/app/controllers/result_elements/tables_controller.rb
+++ b/app/controllers/result_elements/tables_controller.rb
@@ -58,8 +58,11 @@ module ResultElements
     end
 
     def move
-      target = @my_module.results.find_by(id: params[:target_id])
+      target = @my_module.results.active.find_by(id: params[:target_id])
+      return head(:conflict) unless target
+
       result_table = @table.result_table
+
       ActiveRecord::Base.transaction do
         result_table.update!(result: target)
         result_table.result_orderable_element.update!(result: target, position: target.result_orderable_elements.size)

--- a/app/controllers/result_elements/texts_controller.rb
+++ b/app/controllers/result_elements/texts_controller.rb
@@ -37,7 +37,9 @@ module ResultElements
     end
 
     def move
-      target = @my_module.results.find_by(id: params[:target_id])
+      target = @my_module.results.active.find_by(id: params[:target_id])
+      return head(:conflict) unless target
+
       ActiveRecord::Base.transaction do
         @result_text.update!(result: target)
         @result_text.result_orderable_element.update!(result: target, position: target.result_orderable_elements.size)


### PR DESCRIPTION
Jira ticket: [SCI-9403](https://scinote.atlassian.net/browse/SCI-9403)

### What was done
- fix move_targets methods to only return active results
- prevent moving elements to archived results


[SCI-9403]: https://scinote.atlassian.net/browse/SCI-9403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ