### PR TITLE
Fix closing of the dropdown menu for protocol parser import [SCI-9275]

### DIFF
--- a/app/javascript/vue/protocol_import/file_import_modal.vue
+++ b/app/javascript/vue/protocol_import/file_import_modal.vue
@@ -66,6 +66,8 @@
       confirm() {
         let formData = new FormData();
         Array.from(this.files).forEach(file => formData.append('files[]', file, file.name));
+        $('.protocol-import-dropdown').dropdown('toggle');
+
         $.post({ url: this.importUrl, data: formData, processData: false, contentType: false }, (data) => {
             this.state = 'in_progress';
             this.jobId = data.job_id


### PR DESCRIPTION
Jira ticket: [SCI-9275](https://scinote.atlassian.net/browse/SCI-9275)

### What was done
Fix closing of the dropdown menu for protocol parser import

[SCI-9275]: https://scinote.atlassian.net/browse/SCI-9275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ