### PR TITLE
Wrong icon on the Export button in bottom toolbar & Manage columns back button [SCI-9447]

### DIFF
--- a/app/assets/stylesheets/repository_columns/index.scss
+++ b/app/assets/stylesheets/repository_columns/index.scss
@@ -10,6 +10,7 @@
 
     .back-to-column-modal {
       float: left;
+      margin-top: -6px;
     }
   }
 

--- a/app/javascript/vue/components/action_toolbar.vue
+++ b/app/javascript/vue/components/action_toolbar.vue
@@ -15,7 +15,7 @@
             <button class="btn btn-primary dropdown-toggle single-object-action rounded" type="button" id="exportDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
               <i class="sn-icon sn-icon-export"></i>
               <span>{{ action.group_label }}</span>
-              <span class="caret pull-right"></span>
+              <span class="sn-icon sn-icon-down"></span>
             </button>
             <ul class="sci-dropdown dropup dropdown-menu dropdown-menu-right px-2" aria-labelledby="<%= id %>">
               <li v-for="groupAction in action.actions" class="">

--- a/app/views/repository_columns/_delete_column_modal_body.html.erb
+++ b/app/views/repository_columns/_delete_column_modal_body.html.erb
@@ -4,7 +4,7 @@
           title="<%= t("libraries.manange_modal_column.button_tooltip") %>"
           data-modal-url="<%= repository_repository_columns_path(@repository) %>"
           data-action="new">
-    <span class="fas fa-arrow-left"></span>
+    <span class="sn-icon sn-icon-arrow-left"></span>
   </button>
   <h4 class="modal-title"><%= t("repositories.modal_delete_column.title") %></h4>
 </div>

--- a/app/views/repository_columns/_manage_column_modal_content.html.erb
+++ b/app/views/repository_columns/_manage_column_modal_content.html.erb
@@ -4,7 +4,7 @@
           title="<%= t("libraries.manange_modal_column.button_tooltip") %>"
           data-modal-url="<%= repository_repository_columns_path(@repository) %>"
           data-action="new">
-    <span class="fas fa-arrow-left"></span>
+    <span class="sn-icon sn-icon-arrow-left"></span>
   </button>
   <h4 class="modal-title">
     <% if @repository_column.new_record? %>


### PR DESCRIPTION
Jira ticket: [SCI-9447](https://scinote.atlassian.net/browse/SCI-9447)

### What was done
_css fixes for inventory page_



[SCI-9447]: https://scinote.atlassian.net/browse/SCI-9447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ