### PR TITLE
Add missing wording for failed export email/notifications [SCI-9442]

### DIFF
--- a/app/jobs/repositories_export_job.rb
+++ b/app/jobs/repositories_export_job.rb
@@ -99,6 +99,7 @@ class RepositoriesExportJob < ApplicationJob
 
   # Overrides method from FailedDeliveryNotifiableJob concern
   def failed_notification_title
-    I18n.t('repositories.index.export.notification.error.title')
+    I18n.t('activejob.failure_notifiable_job.item_notification_title',
+           item: I18n.t('activejob.failure_notifiable_job.items.repository'))
   end
 end

--- a/app/jobs/repository_stock_zip_export_job.rb
+++ b/app/jobs/repository_stock_zip_export_job.rb
@@ -8,4 +8,9 @@ class RepositoryStockZipExportJob < ZipExportJob
     data = RepositoryStockLedgerZipExport.to_csv(params[:repository_row_ids])
     File.binwrite("#{dir}/export.csv", data)
   end
+
+  def failed_notification_title
+    I18n.t('activejob.failure_notifiable_job.item_notification_title',
+           item: I18n.t('activejob.failure_notifiable_job.items.stock_consumption'))
+  end
 end

--- a/app/jobs/repository_zip_export_job.rb
+++ b/app/jobs/repository_zip_export_job.rb
@@ -37,4 +37,9 @@ class RepositoryZipExportJob < ZipExportJob
                                       params[:my_module_id].present?)
     File.binwrite("#{dir}/export.csv", data)
   end
+
+  def failed_notification_title
+    I18n.t('activejob.failure_notifiable_job.item_notification_title',
+           item: I18n.t('activejob.failure_notifiable_job.items.repository_item'))
+  end
 end

--- a/app/jobs/team_zip_export_job.rb
+++ b/app/jobs/team_zip_export_job.rb
@@ -279,4 +279,9 @@ class TeamZipExportJob < ZipExportJob
 
     csv_file_path
   end
+
+  def failed_notification_title
+    I18n.t('activejob.failure_notifiable_job.item_notification_title',
+           item: I18n.t('activejob.failure_notifiable_job.items.project'))
+  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -258,6 +258,12 @@ en:
     failure_notifiable_job:
       general_notification_title: "Your export failed. Please contact support."
       general_notification_message: "Request timestamp: %{request_timestamp}"
+      item_notification_title: "Your %{item} export failed. Please contact support."
+      items:
+        project: "Projects"
+        repository: "Inventories"
+        repository_item: "Items"
+        stock_consumption: "Stock consumption"
 
   head:
     title: "SciNote | %{title}"


### PR DESCRIPTION
Jira ticket: [SCI-9442](https://scinote.atlassian.net/browse/SCI-9442)

### What was done
Add missing wording for failed export email/notifications 

[SCI-9442]: https://scinote.atlassian.net/browse/SCI-9442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ