### PR TITLE
Projects table header covered by top toolbar on some breakpoint [SCI-9405]

### DIFF
--- a/app/views/projects/index/_header.html.erb
+++ b/app/views/projects/index/_header.html.erb
@@ -19,6 +19,6 @@
       <span class="projects-title name-readonly-placeholder"><%= current_folder&.name || t('projects.index.head_title_archived') %></span>
     </h1>
   </div>
-  <div id="toolbarWrapper" class="toolbar-row" data-width-breakpoint="700">
+  <div id="toolbarWrapper" class="toolbar-row" data-width-breakpoint="750">
   </div>
 </div>


### PR DESCRIPTION
Jira ticket: [SCI-9405](https://scinote.atlassian.net/browse/SCI-9405)

### What was done
_modified header breakpoint_



[SCI-9405]: https://scinote.atlassian.net/browse/SCI-9405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ