### PR TITLE
Hide task share button if user has no permissions for task sharing [SCI-9136]

### DIFF
--- a/app/views/my_modules/_task_flow_and_sharing.html.erb
+++ b/app/views/my_modules/_task_flow_and_sharing.html.erb
@@ -1,7 +1,7 @@
  <div class="task-sharing-and-flows flex items-center gap-2 pl-3">
     <%= render partial: 'my_modules/status_flow/task_flow_button', locals: { my_module: @my_module } if @my_module.my_module_status_flow %>
     <%= javascript_include_tag("my_modules/status_flow") %>
-    <% if current_team.shareable_links_enabled? %>
+    <% if current_team.shareable_links_enabled? && can_share_my_module?(@my_module) %>
       <div class="share-task-container" data-behaviour="vue">
         <share-task-container
           <%= 'shared' if @my_module.shared? %>


### PR DESCRIPTION
Jira ticket: [SCI-9136](https://scinote.atlassian.net/browse/SCI-9136)

### What was done
Hide task share button if user has no permissions for task sharing

[SCI-9136]: https://scinote.atlassian.net/browse/SCI-9136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ