### PR TITLE
Fix issue with text name when importing protocol eln file [SCI-9490]

### DIFF
--- a/app/assets/javascripts/protocols/import_export/import.js
+++ b/app/assets/javascripts/protocols/import_export/import.js
@@ -595,7 +595,7 @@ function importProtocolFromFile(
 
   function stepTextJson(stepTextNode, folderIndex, stepGuid) {
     var json = {};
-
+    json.name = stepTextNode.children('name').text();
     json.contents = $('<div></div>').html(
       stepTextNode.children('contents')
         .html()

--- a/app/utilities/protocols_importer_v2.rb
+++ b/app/utilities/protocols_importer_v2.rb
@@ -137,7 +137,7 @@ class ProtocolsImporterV2
       step: step
     )
 
-    step_text.update!(text: populate_rte(params, step_text))
+    step_text.update!(text: populate_rte(params, step_text), name: params[:name])
 
     create_in_step!(step, step_text)
   end


### PR DESCRIPTION
Jira ticket: [SCI-9490](https://scinote.atlassian.net/browse/SCI-9490)

### What was done
_Fix issue with text name when importing protocol eln file_

#### ToDo:
_N/A_

### Note:
_N/A_


[SCI-9490]: https://scinote.atlassian.net/browse/SCI-9490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ