### PR TITLE
Fix delete results permission helper, don't allow deletion if task is archived [SCI-9503]

### DIFF
--- a/app/permissions/result.rb
+++ b/app/permissions/result.rb
@@ -19,6 +19,7 @@ Canaid::Permissions.register_for(Result) do
 
   can :delete_result do |user, result|
     result.archived? &&
+      !result.my_module.archived_branch? &&
       result.unlocked?(result) &&
       result.my_module.permission_granted?(user, MyModulePermissions::RESULTS_DELETE_ARCHIVED)
   end


### PR DESCRIPTION
Jira ticket: [SCI-9503](https://scinote.atlassian.net/browse/SCI-9503)

### What was done
Fix delete results permission helper, don't allow deletion if task is archived

[SCI-9503]: https://scinote.atlassian.net/browse/SCI-9503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ