### PR TITLE
Refocus on tinymce editor after marvinjs img update [SCI-9515]

### DIFF
--- a/app/assets/javascripts/sitewide/marvinjs_editor.js
+++ b/app/assets/javascripts/sitewide/marvinjs_editor.js
@@ -200,6 +200,8 @@ var MarvinJsEditorApi = (function() {
           $('#modal_link' + json.id + ' .attachment-label').text(json.file_name);
         }
         $(marvinJsModal).modal('hide');
+
+        config.editor.focus();
         config.button.dataset.inProgress = false;
 
         if (MarvinJsEditor.saveCallback) MarvinJsEditor.saveCallback();


### PR DESCRIPTION
Jira ticket: [SCI-9515](https://scinote.atlassian.net/browse/SCI-9515)

### What was done
- refocus on tinymce editor after marvinjs img update

[SCI-9515]: https://scinote.atlassian.net/browse/SCI-9515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ