### PR TITLE
Fixed protocol template table header covered by the list [SCI-9520]

### DIFF
--- a/app/assets/stylesheets/protocols/index.scss
+++ b/app/assets/stylesheets/protocols/index.scss
@@ -20,6 +20,7 @@
       width: 100%;
 
       .dataTables_scrollHead {
+        overflow: visible !important;
 
         thead {
           .sci-checkbox-container {


### PR DESCRIPTION
Jira ticket: [SCI-9520](https://scinote.atlassian.net/browse/SCI-9520)

### What was done
Fixed template table header style to stay visible when it's overflowing its parent content


[SCI-9520]: https://scinote.atlassian.net/browse/SCI-9520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ