### PR TITLE
Fix: "Assign to task" is disabled on a task card instead of hidden [SCI-9548]

### DIFF
--- a/app/javascript/vue/repository_item_sidebar/RepositoryItemSidebar.vue
+++ b/app/javascript/vue/repository_item_sidebar/RepositoryItemSidebar.vue
@@ -149,7 +149,7 @@
                     count: assignedModules ?
                       assignedModules.total_assigned_size : 0
                   }) }}
-                  <a v-if="actions?.assign_repository_row || (inRepository && !defaultColumns?.archived)"
+                  <a v-if="actions?.assign_repository_row && !defaultColumns?.archived"
                     class="btn-text-link font-normal" :class="{
                       'assign-inventory-button': actions?.assign_repository_row,
                       'disabled': actions?.assign_repository_row && actions.assign_repository_row.disabled


### PR DESCRIPTION
Jira ticket: [SCI-9548](https://scinote.atlassian.net/browse/SCI-9548)

### What was done
Hide assign item button when the item is archived in item-card.

[SCI-9548]: https://scinote.atlassian.net/browse/SCI-9548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ