### PR TITLE
Fix results API endpoint, return result elements in includes block instead of attributes [SCI-9553]

### DIFF
--- a/app/serializers/api/v1/result_serializer.rb
+++ b/app/serializers/api/v1/result_serializer.rb
@@ -4,25 +4,27 @@ module Api
   module V1
     class ResultSerializer < ActiveModel::Serializer
       type :results
-      attributes :name, :archived, :result_text, :result_table, :result_asset
+      attributes :name, :archived
       belongs_to :user, serializer: UserSerializer
+      has_one :result_text, key: :text,
+                            serializer: ResultTextSerializer,
+                            class_name: 'ResultText' do |serializer|
+                              serializer.object.result_texts.first
+                            end
+      has_one :result_table, key: :table,
+                             serializer: ResultTableSerializer,
+                             class_name: 'ResultTable' do |serializer|
+                               serializer.object.result_tables.first
+                             end
+      has_one :result_asset, key: :file,
+                             serializer: ResultAssetSerializer,
+                             class_name: 'ResultAsset' do |serializer|
+                               serializer.object.result_assets.first
+                             end
       has_many :result_comments, key: :comments, serializer: CommentSerializer
       has_many :result_orderable_elements, key: :result_elements, serializer: ResultOrderableElementSerializer
-      has_many :assets, serializer: AssetSerializer
 
       include TimestampableModel
-
-      def result_text
-        Api::V1::ResultTextSerializer.new(object.result_texts.first).as_json if object.result_texts.any?
-      end
-
-      def result_table
-        Api::V1::ResultTableSerializer.new(object.result_tables.first).as_json if object.result_tables.any?
-      end
-
-      def result_asset
-        Api::V1::ResultAssetSerializer.new(object.result_assets.first).as_json if object.result_assets.any?
-      end
     end
   end
 end

--- a/app/serializers/api/v1/result_text_serializer.rb
+++ b/app/serializers/api/v1/result_text_serializer.rb
@@ -4,7 +4,7 @@ module Api
   module V1
     class ResultTextSerializer < ActiveModel::Serializer
       type :result_texts
-      attributes :text
+      attributes :name, :text
     end
   end
 end


### PR DESCRIPTION
Jira ticket: [SCI-9553](https://scinote.atlassian.net/browse/SCI-9553)

### What was done
Fix results API endpoint, return result elements in includes block instead of attributes

[SCI-9553]: https://scinote.atlassian.net/browse/SCI-9553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ