### PR TITLE
Hide export button in item card when item has no stock set [SCI-9509]

### DIFF
--- a/app/javascript/vue/repository_item_sidebar/repository_values/RepositoryStockValue.vue
+++ b/app/javascript/vue/repository_item_sidebar/repository_values/RepositoryStockValue.vue
@@ -3,7 +3,7 @@
     <div class="font-inter text-sm font-semibold leading-5 relative">
       <span>{{ colName }}</span>
       <a style="text-decoration: none;" class="absolute right-0 btn-text-link font-normal export-consumption-button"
-        v-if="permissions?.can_export_repository_stock === true" :data-rows="JSON.stringify([repositoryRowId])"
+        v-if="permissions?.can_export_repository_stock === true && colVal?.stock_formatted" :data-rows="JSON.stringify([repositoryRowId])"
         :data-object-id="repositoryId">
         {{ i18n.t('repositories.item_card.stock_export') }}
       </a>


### PR DESCRIPTION
Jira ticket: [SCI-9509](https://scinote.atlassian.net/browse/SCI-9509)

### What was done
_Hide export button in item card when item has no stock set_

#### ToDo:
_N/A_

### Note:
_N/A_


[SCI-9509]: https://scinote.atlassian.net/browse/SCI-9509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ