### PR TITLE
Fix team permission scope for service API [SCI-9611]

### DIFF
--- a/app/controllers/api/service/base_controller.rb
+++ b/app/controllers/api/service/base_controller.rb
@@ -73,6 +73,7 @@ module Api
 
       def load_team
         @team = current_user.teams.find(params.require(:team_id))
+        current_user.permission_team = @team
         raise PermissionError.new(Team, :read) unless can_read_team?(@team)
       end
 


### PR DESCRIPTION
Jira ticket: [SCI-9611](https://scinote.atlassian.net/browse/SCI-9611)

### What was done
Fix team permission scope for service API

[SCI-9611]: https://scinote.atlassian.net/browse/SCI-9611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ