### PR TITLE
Add timestap to bypass Chrome cache for TinyMCE images [SCI-9597]

### DIFF
--- a/app/javascript/packs/tiny_mce.js
+++ b/app/javascript/packs/tiny_mce.js
@@ -205,6 +205,12 @@ window.TinyMCE = (() => {
           cache_suffix: '?v=6.5.1-19', // This suffix should be changed any time library is updated
           selector,
           skin: false,
+          editimage_fetch_image: img => new Promise((resolve) => {
+            // Appending a timestamp to an image URL bypasses Chrome’s cache, resolving occasional CORS errors
+            fetch(img.src + '?t=' + new Date().getTime())
+              .then(response => response.blob())
+              .then(blob => resolve(blob));
+          }),
           content_css: false,
           content_style: contentStyle,
           convert_urls: false,


### PR DESCRIPTION
Jira ticket: [SCI-9597](https://scinote.atlassian.net/browse/SCI-9597)

### What was done
- add timestap to bypass Chrome cache for TinyMCE images 

[SCI-9597]: https://scinote.atlassian.net/browse/SCI-9597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ