### PR TITLE
Fixed multiple subsequent MSOffice files being created [SCI-9516]

### DIFF
--- a/app/javascript/vue/shared/content/attachments/mixins/wopi_file_modal.js
+++ b/app/javascript/vue/shared/content/attachments/mixins/wopi_file_modal.js
@@ -19,16 +19,17 @@ export default {
         }
       });
 
-      $wopiModal.find('form')
-        .on('submit', () => {
-          animateSpinner(null, true);
-        })
+      $wopiModal.find('form').on('submit', () => {
+        animateSpinner(null, true);
+      })
         .on(
           'ajax:success',
           (e, data, status) => {
             animateSpinner(null, false);
             if (status === 'success') {
               $wopiModal.modal('hide');
+              $wopiModal.find('form').off('submit');
+              $wopiModal.find('form').off('ajax:success');
               window.open(data.edit_url, '_blank');
               window.focus();
             } else {
@@ -36,7 +37,8 @@ export default {
             }
             requestCallback(e, data, status);
           }
-        ).on('ajax:error', function(ev, response) {
+        )
+        .on('ajax:error', function(ev, response) {
           let element;
           let msg;
 


### PR DESCRIPTION
Jira ticket: [SCI-9516](https://scinote.atlassian.net/browse/SCI-9516)

### What was done
Fixed initWopiFileModal method in wopi_file_modal.js mixin to prevent multiple ajax:success calls that were happening


[SCI-9516]: https://scinote.atlassian.net/browse/SCI-9516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ