### PR TITLE
Show "leave page" alert only if Hot cell is in edit mode [SCI-9641]

### DIFF
--- a/app/javascript/vue/shared/content/table.vue
+++ b/app/javascript/vue/shared/content/table.vue
@@ -126,8 +126,9 @@
       }
     },
     created() {
+      this.editingCell = false;
       window.addEventListener('beforeunload', (e) => {
-        if (this.editingTable) {
+        if (this.editingCell) {
           e.preventDefault();
           e.returnValue = '';
         }
@@ -268,12 +269,23 @@
           },
           afterSelectionEnd: () => {
             if (this.editingTable == false) return;
+            this.editingCell = false;
             this.updatingTableData = true;
 
             this.$nextTick(() => {
               this.update();
             });
-          }
+          },
+          beforeChange: () => {
+            this.editingCell = false;
+          },
+          beforeKeyDown: (e) => {
+            if (e.keyCode === 27) { // esc
+              this.editingCell = false;
+              return;
+            }
+            this.editingCell = true;
+          },
         });
         this.$nextTick(this.tableObject.render);
       }


### PR DESCRIPTION
Jira ticket: [SCI-9641](https://scinote.atlassian.net/browse/SCI-9641)

### What was done
Only show the leave page alert if some change is not saved!
Also if the user enters the edit mode of a cell, but hits ESC without changing anything, it will not be considered as a change and thus not trigger an alert on window reload/close.



[SCI-9641]: https://scinote.atlassian.net/browse/SCI-9641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ