### PR TITLE
Column misalignment when exporting inventory with Korean characters [SCI-9307]

### DIFF
--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -328,6 +328,7 @@ class RepositoriesController < ApplicationController
       render json: {
         html: render_to_string(
           partial: 'shared/flash_errors',
+          formats: :html,
           locals: { error_title: t('repositories.import_records.error_message.errors_list_title'),
                     error: t('repositories.import_records.error_message.no_repository_name') }
         )

--- a/app/jobs/repository_zip_export_job.rb
+++ b/app/jobs/repository_zip_export_job.rb
@@ -35,7 +35,7 @@ class RepositoryZipExportJob < ZipExportJob
                                       repository,
                                       nil,
                                       params[:my_module_id].present?)
-    File.binwrite("#{dir}/export.csv", data)
+    File.binwrite("#{dir}/export.csv", data.encode('UTF-8', invalid: :replace, undef: :replace))
   end
 
   def failed_notification_title


### PR DESCRIPTION
Jira ticket: [SCI-9307](https://scinote.atlassian.net/browse/SCI-9307)

### What was done
Ensure that the export CSV inventory items are in UTF-8

[SCI-9307]: https://scinote.atlassian.net/browse/SCI-9307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ