### PR TITLE
Fix outside-click directive to not kill Turbolinks [SCI-9675]

### DIFF
--- a/app/javascript/packs/vue/directives/outside_click.js
+++ b/app/javascript/packs/vue/directives/outside_click.js
@@ -6,8 +6,6 @@
 export default {
   bind(el, binding, vnode) {
     el._vueClickOutside_ = (e) => {
-      e.stopPropagation();
-
       let clickedOnExcludedEl = false;
       const { exclude } = binding.value;
       exclude.forEach(refName => {


### PR DESCRIPTION
Jira ticket: [SCI-9675](https://scinote.atlassian.net/browse/SCI-9675)

### What was done
The click-outside vue directive binds on all document clicks and then does e.stopPropagation, which kills the turbolinks functionality.

We probably had this issue before, but after this release it was present on all pages, due to the top toolbar using the select.vue component, which uses this directive.

[SCI-9675]: https://scinote.atlassian.net/browse/SCI-9675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ