### PR TITLE
Allow data-turbolinks attribute in sanitization [SCI-9683]

### DIFF
--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -328,6 +328,7 @@ class Constants
   config[:attributes][:all] << 'contenteditable'
   config[:attributes]['img'] << 'data-mce-token'
   config[:attributes]['img'] << 'data-source-type'
+  config[:attributes]['a'] << 'data-turbolinks'
   config[:protocols]['img']['src'] << 'data'
   INPUT_SANITIZE_CONFIG = Sanitize::Config.freeze_config(config)
 


### PR DESCRIPTION
Jira ticket: [SCI-9683](https://scinote.atlassian.net/browse/SCI-9683)

### What was done
Allow data-turbolinks attribute in sanitization