### PR TITLE
(fix) Red dot reminder is not upadated on item card [SCI-9818]

### DIFF
--- a/app/javascript/vue/repository_item_sidebar/RepositoryItemSidebar.vue
+++ b/app/javascript/vue/repository_item_sidebar/RepositoryItemSidebar.vue
@@ -279,6 +279,11 @@ export default {
       inRepository: false
     }
   },
+  provide() {
+    return {
+      reloadRepoItemSidebar: this.reload,
+    }
+  },
   created() {
     window.repositoryItemSidebarComponent = this;
   },

--- a/app/javascript/vue/repository_item_sidebar/repository_values/date_time_component.vue
+++ b/app/javascript/vue/repository_item_sidebar/repository_values/date_time_component.vue
@@ -54,9 +54,10 @@
         endDate: null,
         error: null,
         defaultStartDate: null,
-        defaultEndDate: null
+        defaultEndDate: null,
       }
     },
+    inject: ['reloadRepoItemSidebar'],
     props: {
       mode: String,
       range: { type: Boolean, default: false },
@@ -171,7 +172,10 @@
           success: () => {
             this.defaultStartDate = this.startDate;
             this.defaultEndDate = this.endDate;
-            if ($('.dataTable')[0]) $('.dataTable').DataTable().ajax.reload(null, false);
+            if ($('.dataTable')[0]) {
+              $('.dataTable').DataTable().ajax.reload(null, false);
+              this.reloadRepoItemSidebar();
+            }
           }
         });
       },


### PR DESCRIPTION
Jira ticket: [SCI-9818](https://scinote.atlassian.net/browse/SCI-9818)

### What was done
Fixed reminder not updating correctly on the FE and added control over how far into the future from today's date the reminder should still trigger


[SCI-9818]: https://scinote.atlassian.net/browse/SCI-9818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ