### PR TITLE
Escape special regexp symbols in clonable name generation [SCI-9819]

### DIFF
--- a/app/models/concerns/cloneable.rb
+++ b/app/models/concerns/cloneable.rb
@@ -10,7 +10,7 @@ module Cloneable
     last_clone_number =
       parent.public_send(self.class.table_name)
             .select("substring(#{self.class.table_name}.name, '(?:^#{clone_label} )(\\d+)')::int AS clone_number")
-            .where('name ~ ?', "^#{clone_label} \\d+ - #{name}$")
+            .where('name ~ ?', "^#{clone_label} \\d+ - #{Regexp.escape(name)}$")
             .order(clone_number: :asc)
             .last&.clone_number
 


### PR DESCRIPTION
Jira ticket: [SCI-9819](https://scinote.atlassian.net/browse/SCI-9819)

### What was done
Escape special regexp symbols in clonable name generation

[SCI-9819]: https://scinote.atlassian.net/browse/SCI-9819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ