### PR TITLE
Remove 'There is a change on assigned task' notification category [SCI-9767]

### DIFF
--- a/config/initializers/extends/notification_extends.rb
+++ b/config/initializers/extends/notification_extends.rb
@@ -106,7 +106,6 @@ class NotificationExtends
         designate_user_to_my_module_activity
         undesignate_user_from_my_module_activity
       ],
-      my_module_modified: %I[],
       my_module_due_date: %I[
         my_module_due_date_reminder
       ],

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3432,7 +3432,6 @@ en:
       other: "Others"
     sub_groups:
       my_module_designation: "You were assigned to or unassigned from a task"
-      my_module_modified: "There is a change on assigned task"
       my_module_due_date: "Due date & time reminder on assigned task (24h before)"
       my_module_comments: "A comment was added or edited on a task you are assigned to"
       project_experiment_access: "You were added or removed from a Project"


### PR DESCRIPTION
Jira ticket: [SCI-9767](https://scinote.atlassian.net/browse/SCI-9767)

### What was done
- remove 'There is a change on assigned task' notification category
