### PR TITLE
Add conflict check for WOPI lock AssetSyncController [SCI-9758]

### DIFF
--- a/app/models/asset_sync_token.rb
+++ b/app/models/asset_sync_token.rb
@@ -18,7 +18,7 @@ class AssetSyncToken < ApplicationRecord
   end
 
   def conflicts?(token)
-    version_token != token
+    asset.locked? || version_token != token
   end
 
   private


### PR DESCRIPTION
Jira ticket: [SCI-9758](https://scinote.atlassian.net/browse/SCI-9758)

### What was done
- add conflict check for WOPI lock AssetSyncController 

[SCI-9758]: https://scinote.atlassian.net/browse/SCI-9758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ