### PR TITLE
Fix prepend_title_page method in pdf_job [SCI-9623]

### DIFF
--- a/app/jobs/reports/pdf_job.rb
+++ b/app/jobs/reports/pdf_job.rb
@@ -220,9 +220,9 @@ module Reports
       merged_file
     end
 
-    def prepend_title_page(file, template, report, renderer)
-      unless File.exist?(Rails.root.join('app', 'views', 'reports', 'templates', template, 'cover.html.erb'))
-        return file
+    def prepend_title_page
+      unless File.exist?(Rails.root.join('app', 'views', 'reports', 'templates', @template, 'cover.html.erb'))
+        return @file
       end
 
       total_pages = 0


### PR DESCRIPTION
Jira ticket: [SCI-9623](https://scinote.atlassian.net/browse/SCI-9623)

### What was done
- fix prepend_title_page method in pdf_job
