### PR TITLE
(fix) Text size on an archived task and 'Collapse all' button on results [SCI-9582]

### DIFF
--- a/app/javascript/vue/shared/content/text.vue
+++ b/app/javascript/vue/shared/content/text.vue
@@ -113,7 +113,7 @@
     },
     computed: {
       wrapTables() {
-        const container = $(`<span>${this.element.attributes.orderable.text_view}</span>`);
+        const container = $(`<span class="text-base">${this.element.attributes.orderable.text_view}</span>`);
         container.find('table').toArray().forEach((table) => {
           if ($(table).parent().hasClass('table-wrapper')) return;
           $(table).css('float', 'none').wrapAll(`


### PR DESCRIPTION

Jira ticket: [SCI-9582](https://scinote.atlassian.net/browse/SCI-9582)

### What was done
added text-base to the parent span


[SCI-9582]: https://scinote.atlassian.net/browse/SCI-9582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ