### PR TITLE
(fix) Wording improvments for the 'Delete attachments' modal [SCI-9845]

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3524,10 +3524,10 @@ en:
       thumbnail_html: "Thumbnail"
       list_html: "List"
     delete_file_modal:
-      title: "Delete attachment"
+      title: "Delete file"
       description_1_html: "You are about to delete <b>%{file_name}</b></p>"
       description_2: "Are you sure you want to continue?"
-      confirm_button: "Delete attachment"
+      confirm_button: "Delete"
     empty_office_file:
       description: "The file is empty. Please add some data before saving the file."
       reload: "Reload file"


### PR DESCRIPTION
Jira ticket: [SCI-9845](https://scinote.atlassian.net/browse/SCI-9845)

### What was done
Updated the en.yml file with the new wording


[SCI-9845]: https://scinote.atlassian.net/browse/SCI-9845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ