### PR TITLE
Smart annotations are not shown in text fields on the item card [SCI-9888]

### DIFF
--- a/app/javascript/vue/repository_item_sidebar/repository_values/RepositoryTextValue.vue
+++ b/app/javascript/vue/repository_item_sidebar/repository_values/RepositoryTextValue.vue
@@ -27,15 +27,16 @@
                  @update="update"
                  className="px-3" />
     </div>
-    <div v-else-if="colVal?.edit"
-          ref="textRef"
-          class="text-sn-dark-grey box-content text-sm font-normal leading-5 overflow-y-auto pr-3 rounded w-[calc(100%-2rem)]]"
-          :class="{
-            'max-h-[4rem]': collapsed,
-            'max-h-[40rem]': !collapsed
-          }"
+    <div v-else-if="colVal?.view"
+         ref="textRef"
+         v-html="colVal?.view"
+         class="text-sn-dark-grey box-content text-sm font-normal leading-5
+                overflow-y-auto pr-3 rounded w-[calc(100%-2rem)]]"
+         :class="{
+           'max-h-[4rem]': collapsed,
+           'max-h-[40rem]': !collapsed
+         }"
     >
-      {{ colVal?.edit }}
     </div>
     <div v-else class="text-sn-dark-grey font-inter text-sm font-normal leading-5 pr-3 py-2 w-[calc(100%-2rem)]]">
       {{ i18n.t("repositories.item_card.repository_text_value.no_text") }}


### PR DESCRIPTION
Jira ticket: [SCI-9888](https://scinote.atlassian.net/browse/SCI-9888)

### What was done
Fix smart annotation in item card text columns for users without edit permissions.

[SCI-9888]: https://scinote.atlassian.net/browse/SCI-9888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ