### PR TITLE
Align visibility icon for password field in error state [SCI-9889]

### DIFF
--- a/app/assets/stylesheets/shared_styles/elements/input_fields.scss
+++ b/app/assets/stylesheets/shared_styles/elements/input_fields.scss
@@ -102,6 +102,10 @@
       top: 6px;
       width: 25px;
     }
+
+    .sn-icon {
+      bottom: 12px;
+    }
   }
 
   &.error {


### PR DESCRIPTION
Jira ticket: [SCI-9889](https://scinote.atlassian.net/browse/SCI-9889)

### What was done
_Align visibility icon for password field in error state_

#### ToDo:
_N/A_

### Note:
_N/A_


[SCI-9889]: https://scinote.atlassian.net/browse/SCI-9889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ