### PR TITLE
Fix conflicts in asset sync caused by preview generation [SCI-9935]

### DIFF
--- a/app/models/asset_sync_token.rb
+++ b/app/models/asset_sync_token.rb
@@ -10,7 +10,7 @@ class AssetSyncToken < ApplicationRecord
   validates :token, uniqueness: true, presence: true
 
   def version_token
-    asset.updated_at.to_i.to_s
+    asset.file.checksum
   end
 
   def token_valid?


### PR DESCRIPTION
Jira ticket: [SCI-9935](https://scinote.atlassian.net/browse/SCI-9935)

### What was done
Fix conflicts in asset sync caused by preview generation. Because preview generation bumps the updated_at timestamp of a file, this was not a good choice for the version_token. Switched to file checksum, so it's now based on file contents.

[SCI-9935]: https://scinote.atlassian.net/browse/SCI-9935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ