### PR TITLE
Add migration fixing wrong team reference for assets in repository snapshots [SCI-9929]

### DIFF
--- a/db/migrate/20240103100053_fix_team_id_for_cloned_repository_assets.rb
+++ b/db/migrate/20240103100053_fix_team_id_for_cloned_repository_assets.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class FixTeamIdForClonedRepositoryAssets < ActiveRecord::Migration[7.0]
+  def up
+    execute(
+      'UPDATE "assets" ' \
+      'SET "team_id" = "repositories"."team_id" ' \
+      'FROM "repositories" ' \
+      'INNER JOIN "repository_columns" ON "repository_columns"."repository_id" = "repositories"."id" ' \
+      'INNER JOIN "repository_cells" ON "repository_cells"."repository_column_id" = "repository_columns"."id" ' \
+      'INNER JOIN "repository_asset_values" ON "repository_asset_values"."id" = "repository_cells"."value_id" ' \
+      'AND "repository_cells"."value_type" = \'RepositoryAssetValue\' ' \
+      'WHERE "assets"."team_id" != "repositories"."team_id"'
+    )
+  end
+end


### PR DESCRIPTION
Jira ticket: [SCI-9929](https://scinote.atlassian.net/browse/SCI-9929)

### What was done
Add migration fixing wrong team reference for assets in repository snapshots

[SCI-9929]: https://scinote.atlassian.net/browse/SCI-9929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ