### PR TITLE
(fix) Background of opened modal from item card is not disabled [SCI-9931]

### DIFF
--- a/app/views/shared/_repository_row_sidebar.html.erb
+++ b/app/views/shared/_repository_row_sidebar.html.erb
@@ -1,7 +1,7 @@
 <div
     id="repositoryItemSidebar"
     data-behaviour="vue"
-    class="fixed top-0 right-0 h-full z-[2030]"
+    class="fixed top-0 right-0 h-full z-[2039]"
     >
     <repository-item-sidebar />
 </div>


### PR DESCRIPTION


Jira ticket: [SCI-9931](https://scinote.atlassian.net/browse/SCI-9931)

### What was done
Changed z-index so that the modal opened from the item card correctly layers on top of it.


[SCI-9931]: https://scinote.atlassian.net/browse/SCI-9931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ