### PR TITLE
Remove blur event listener from legacy inline edit [SCI-9951]

### DIFF
--- a/app/assets/javascripts/shared/inline_editing.js
+++ b/app/assets/javascripts/shared/inline_editing.js
@@ -148,9 +148,6 @@ let inlineEditing = (function() {
         $(editBlocks).click();
       }
     })
-    .on('blur', `${editBlocks} textarea, ${editBlocks} input`, function(e) {
-      saveAllEditFields();
-    })
     .on('click', editBlocks, function(e) {
     // 'A' mean that, if we click on <a></a> element we will not go in edit mode
       var container = $(this);


### PR DESCRIPTION
Jira ticket: [SCI-9951](https://scinote.atlassian.net/browse/SCI-9951)

### What was done
- remove blur event listener from legacy inline edit because it is in conflict with cancel button


[SCI-9951]: https://scinote.atlassian.net/browse/SCI-9951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ