### PR TITLE
Change to asset_download_path in Asset Serializer [SCI-9806]

### DIFF
--- a/app/serializers/asset_serializer.rb
+++ b/app/serializers/asset_serializer.rb
@@ -120,7 +120,7 @@ class AssetSerializer < ActiveModel::Serializer
   def urls
     urls = {
       preview: asset_file_preview_path(object),
-      download: (rails_blob_path(object.file, disposition: 'attachment') if attached),
+      download: (asset_download_path(object) if attached),
       load_asset: load_asset_path(object),
       asset_file: asset_file_url_path(object),
       marvin_js: marvin_js_asset_path(object),


### PR DESCRIPTION
Jira ticket: [SCI-9806](https://scinote.atlassian.net/browse/SCI-9806)

### What was done
- change to asset_download_path in Asset Serializer

[SCI-9806]: https://scinote.atlassian.net/browse/SCI-9806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ