### PR TITLE
(fix) Can not add text/number to item card from task assigned item table [SCI-9834]

### DIFF
--- a/app/views/my_modules/repositories/_full_view_modal.html.erb
+++ b/app/views/my_modules/repositories/_full_view_modal.html.erb
@@ -1,4 +1,4 @@
-<div class="modal custom-z-index" id="myModuleRepositoryFullViewModal" data-keyboard="false" tabindex="-1" role="dialog">
+<div class="modal custom-z-index" id="myModuleRepositoryFullViewModal" data-keyboard="false" role="dialog" >
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">


### PR DESCRIPTION
Jira ticket: [SCI-9834](https://scinote.atlassian.net/browse/SCI-9834)

### What was done
Fixed the issue preventing properly editing any input fields on item card when opened from task/assigned item table. This was also causing repeated calls to BE due to immediate loss of focus from the input field when clicked in it. Cause: bootstrap modal with an unnecessary boilerplate prop.

[SCI-9834]: https://scinote.atlassian.net/browse/SCI-9834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ