### PR TITLE
Increase timeout for PDF generation in Grover config [SCI-9969]

### DIFF
--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -428,6 +428,9 @@ class Constants
   FAST_STATUS_POLLING_INTERVAL = 5000
   SLOW_STATUS_POLLING_INTERVAL = 10000
 
+  # Grover timeout in ms
+  GROVER_TIMEOUT_MS = 300000
+
   #                             )       \   /      (
   #                            /|\      )\_/(     /|\
   #   *                       / | \    (/\|/\)   / | \                      *

--- a/config/initializers/grover.rb
+++ b/config/initializers/grover.rb
@@ -4,6 +4,7 @@ Grover.configure do |config|
   config.options = {
     cache: false,
     executable_path: './bin/chromium',
-    launch_args: ['--no-sandbox']
+    launch_args: ['--no-sandbox'],
+    timeout: Constants::GROVER_TIMEOUT_MS
   }
 end


### PR DESCRIPTION
Jira ticket: [SCI-9969](https://scinote.atlassian.net/browse/SCI-9969)

### What was done
Increase timeout for PDF generation in Grover config

[SCI-9969]: https://scinote.atlassian.net/browse/SCI-9969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ