### PR TITLE
(fix) Modal opened behind the item card [SCI-10008]

### DIFF
--- a/app/javascript/vue/repository_item_sidebar/RepositoryItemSidebar.vue
+++ b/app/javascript/vue/repository_item_sidebar/RepositoryItemSidebar.vue
@@ -497,6 +497,8 @@ export default {
       }
     },
     toggleShowHideSidebar(repositoryRowUrl, myModuleId = null, initialSectionId = null) {
+      // opening from a bootstrap modal - should close the modal upon itemcard open
+      this.handleOpeningFromBootstrapModal();
       if (initialSectionId) {
         this.initialSectionId = initialSectionId;
       } else this.initialSectionId = null;
@@ -528,6 +530,15 @@ export default {
       this.myModuleId = myModuleId;
       this.loadRepositoryRow(repositoryRowUrl);
       this.currentItemUrl = repositoryRowUrl;
+    },
+    handleOpeningFromBootstrapModal() {
+      const layout = document.querySelector('.sci--layout');
+      const openModals = layout.querySelectorAll('.modal');
+      openModals.forEach((modal) => {
+        if ($(modal).hasClass('in') && !$(modal).hasClass('full-screen')) {
+          $(modal).modal('hide');
+        }
+      });
     },
     loadRepositoryRow(repositoryRowUrl, scrollTop = 0) {
       this.dataLoading = true

--- a/app/views/shared/_repository_row_sidebar.html.erb
+++ b/app/views/shared/_repository_row_sidebar.html.erb
@@ -1,7 +1,7 @@
 <div
     id="repositoryItemSidebar"
     data-behaviour="vue"
-    class="fixed top-0 right-0 h-full z-[2040]"
+    class="fixed top-0 right-0 h-full z-[2039]"
     >
     <repository-item-sidebar />
 </div>


### PR DESCRIPTION
Jira ticket: [SCI-10008](https://scinote.atlassian.net/browse/SCI-10008)

### What was done
Fixed modals opening in front of item card and handled edge-case when opening item card from experimentDetailsModal


[SCI-10008]: https://scinote.atlassian.net/browse/SCI-10008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ