### PR TITLE
(fix) At click to relationship number in INV table item card is opened from the top [SCI-9927]

### DIFF
--- a/app/javascript/vue/repository_item_sidebar/repository_values/ScrollSpy.vue
+++ b/app/javascript/vue/repository_item_sidebar/repository_values/ScrollSpy.vue
@@ -200,7 +200,9 @@ export default {
         });
       } else {
         // scroll to the start of a section's threshold, adjusted for the center thumb value (true center)
-        scrollableArea.scrollTop = foundThreshold.from - this.centerOfScrollThumb;
+        this.$nextTick(() => {
+          scrollableArea.scrollTop = foundThreshold.from - this.centerOfScrollThumb;
+        });
       }
       this.flashTitleColor(domElToScrollTo);
 


### PR DESCRIPTION

Jira ticket: [SCI-9927](https://scinote.atlassian.net/browse/SCI-9927)

### What was done
Fixed navigation to relationships section when a relationship number in inventory table is clicked by waiting for the next DOM update flush


[SCI-9927]: https://scinote.atlassian.net/browse/SCI-9927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ