### PR TITLE
Fix inclusion of TinyMCE images in project exports [SCI-10051]

### DIFF
--- a/app/models/concerns/tiny_mce_images.rb
+++ b/app/models/concerns/tiny_mce_images.rb
@@ -3,6 +3,7 @@
 module TinyMceImages
   extend ActiveSupport::Concern
 
+  # rubocop:disable Metrics/BlockLength:
   included do
     has_many :tiny_mce_assets,
              as: :object,
@@ -22,18 +23,13 @@ module TinyMceImages
       tiny_mce_assets.each do |tm_asset|
         next unless tm_asset&.image&.attached?
 
-        begin
-          new_tm_asset_src = tm_asset.convert_variant_to_base64(tm_asset.preview)
-        rescue ActiveStorage::FileNotFoundError
-          next
-        end
         html_description = Nokogiri::HTML(description)
         tm_asset_to_update = html_description.css(
           "img[data-mce-token=\"#{Base62.encode(tm_asset.id)}\"]"
         )[0]
         next unless tm_asset_to_update
 
-        tm_asset_to_update.attributes['src'].value = new_tm_asset_src
+        tm_asset_to_update.attributes['src'].value = tm_asset.convert_to_base64
         description = html_description.css('body').inner_html.to_s
       end
       description
@@ -225,4 +221,5 @@ module TinyMceImages
       end
     end
   end
+  # rubocop:enable Metrics/BlockLength:
 end

--- a/app/models/tiny_mce_asset.rb
+++ b/app/models/tiny_mce_asset.rb
@@ -203,6 +203,14 @@ class TinyMceAsset < ApplicationRecord
     image&.blob
   end
 
+  def convert_to_base64
+    encoded_data = Base64.strict_encode64(image.download)
+    "data:#{image.blob.content_type};base64,#{encoded_data}"
+  rescue StandardError => e
+    Rails.logger.error e.message
+    "data:#{image.blob.content_type};base64,"
+  end
+
   def duplicate_file(to_asset)
     return unless image.attached?
 


### PR DESCRIPTION
Jira ticket: [SCI-10051](https://scinote.atlassian.net/browse/SCI-10051)

### What was done
Fix inclusion of TinyMCE images in project exports

[SCI-10051]: https://scinote.atlassian.net/browse/SCI-10051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ