### PR TITLE
(fix) Content disappears until page refresh when moving it between results [SCI-10074]

### DIFF
--- a/app/javascript/vue/results/result.vue
+++ b/app/javascript/vue/results/result.vue
@@ -192,7 +192,7 @@ export default {
   },
   watch: {
     resultToReload() {
-      if (this.resultToReload === this.result.id) {
+      if (Number(this.resultToReload) === Number(this.result.id)) {
         this.loadElements();
         this.loadAttachments();
       }


### PR DESCRIPTION
Jira ticket: [SCI-10074](https://scinote.atlassian.net/browse/SCI-10074)

### What was done
Comparison block used for re-rendering updated result data was comparing two different types.
Fixed by casting variables used in the comparison to the same (number) type.

[SCI-10074]: https://scinote.atlassian.net/browse/SCI-10074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ