### PR TITLE
(fix) CSS: Error message for too big file in inventory table [SCI-10029]

### DIFF
--- a/app/assets/stylesheets/repositories.scss
+++ b/app/assets/stylesheets/repositories.scss
@@ -335,8 +335,8 @@
       }
 
       &::before {
-        @include font-small;
-        bottom: -15px;
+        font-size: x-small;
+        bottom: -18px;
         color: $brand-danger;
         content: attr(data-error-text);
         left: 0;


### PR DESCRIPTION
Jira ticket: [SCI-10029](https://scinote.atlassian.net/browse/SCI-10029)

### What was done
Fixed styles for error message for 'file too large to upload fail'


[SCI-10029]: https://scinote.atlassian.net/browse/SCI-10029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ