### PR TITLE
(fix) Spacing between lines in RTF is not correct [SCI-9923]

### DIFF
--- a/app/assets/stylesheets/shared/smart_annotation.scss
+++ b/app/assets/stylesheets/shared/smart_annotation.scss
@@ -236,3 +236,7 @@
 .sa-link {
   pointer-events: initial;
 }
+
+.atwho-inserted {
+  line-height: 16px;
+}


### PR DESCRIPTION
Jira ticket: [SCI-9923](https://scinote.atlassian.net/browse/SCI-9923)

### What was done
Fixed too large spacing when smart annotations were used by specifying a line height
