### PR TITLE
Prevent any event on Select's button [SCI-10128]

### DIFF
--- a/app/javascript/vue/shared/select.vue
+++ b/app/javascript/vue/shared/select.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-click-outside="close" @click="toggle" ref="container" class="sn-select" :class="{ 'sn-select--open': isOpen, 'sn-select--blank': !valueLabel, 'disabled': disabled }">
     <slot>
-      <button ref="focusElement" class="sn-select__value">
+      <button ref="focusElement" class="sn-select__value" @click.prevent="">
         <span>{{ valueLabel || (placeholder || i18n.t('general.select')) }}</span>
       </button>
       <i class="sn-icon" :class="{ 'sn-icon-down': !isOpen, 'sn-icon-up': isOpen}"></i>
@@ -55,7 +55,7 @@ import { vOnClickOutside } from '@vueuse/components';
 
 export default {
   name: 'Select',
-  emits: ['close', 'reached-end', 'open', 'change'],
+  emits: ['close', 'reached-end', 'open', 'change', 'focus'],
   props: {
     withClearButton: { type: Boolean, default: false },
     withEditCursor: { type: Boolean, default: false },


### PR DESCRIPTION
Jira ticket: [SCI-10128](https://scinote.atlassian.net/browse/SCI-10128)

### What was done
This is related to the quartzy wizard.
For some reason, the window is reloaded when opening a Team Select in the team-lab matching step.

[SCI-10128]: https://scinote.atlassian.net/browse/SCI-10128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ