### PR TITLE
Set placeholder color for shared task modal description (textarea) field [SCI-10120]

### DIFF
--- a/app/assets/stylesheets/my_modules/protocol.scss
+++ b/app/assets/stylesheets/my_modules/protocol.scss
@@ -102,4 +102,10 @@
   .shareable-link-disclaimer {
     color: var(--sn-grey);
   }
+
+  .sci-input-container-v2 {
+    textarea::placeholder {
+      color: var(--sn-grey);
+    }
+  }
 }


### PR DESCRIPTION
Jira ticket: [SCI-10120](https://scinote.atlassian.net/browse/SCI-10120)

### What was done
_Set placeholder color for shared task modal description (textarea) field_

#### ToDo:
_N/A_

### Note:
_N/A_


[SCI-10120]: https://scinote.atlassian.net/browse/SCI-10120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ