### PR TITLE
Fix snapshoting for LinkedRepository caused by external_id uniqueness constraint [SCI-9817]

### DIFF
--- a/app/controllers/my_module_repository_snapshots_controller.rb
+++ b/app/controllers/my_module_repository_snapshots_controller.rb
@@ -34,7 +34,7 @@ class MyModuleRepositorySnapshotsController < ApplicationController
   end
 
   def create
-    repository_snapshot = RepositorySnapshot.create_preliminary(@repository, @my_module, current_user)
+    repository_snapshot = RepositorySnapshot.create_preliminary!(@repository, @my_module, current_user)
     RepositorySnapshotProvisioningJob.perform_later(repository_snapshot)
 
     render json: {

--- a/app/models/my_module_status_consequences/repository_snapshot.rb
+++ b/app/models/my_module_status_consequences/repository_snapshot.rb
@@ -8,7 +8,7 @@ module MyModuleStatusConsequences
 
     def forward(my_module)
       my_module.assigned_repositories.each do |repository|
-        repository_snapshot = ::RepositorySnapshot.create_preliminary(repository, my_module)
+        repository_snapshot = ::RepositorySnapshot.create_preliminary!(repository, my_module)
         service = Repositories::SnapshotProvisioningService.call(repository_snapshot: repository_snapshot)
 
         unless service.succeed?

--- a/app/models/repository_snapshot.rb
+++ b/app/models/repository_snapshot.rb
@@ -37,17 +37,16 @@ class RepositorySnapshot < RepositoryBase
       .where(my_module: { experiments: { project: project } })
   }
 
-  def self.create_preliminary(repository, my_module, created_by = nil)
+  def self.create_preliminary!(repository, my_module, created_by = nil)
     created_by ||= repository.created_by
-    repository_snapshot = repository.dup.becomes(RepositorySnapshot)
-    repository_snapshot.assign_attributes(type: RepositorySnapshot.name,
-                                          original_repository: repository,
-                                          my_module: my_module,
-                                          created_by: created_by,
-                                          team: my_module.experiment.project.team,
-                                          permission_level: Extends::SHARED_OBJECTS_PERMISSION_LEVELS[:not_shared])
-    repository_snapshot.provisioning!
-    repository_snapshot.reload
+    create!(
+      name: repository.name,
+      original_repository: repository,
+      team: my_module.experiment.project.team,
+      status: :provisioning,
+      my_module:,
+      created_by:
+    )
   end
 
   def default_table_state


### PR DESCRIPTION
Jira ticket: [SCI-9817](https://scinote.atlassian.net/browse/SCI-9817)

### What was done
Fix snapshoting for LinkedRepository caused by external_id uniqueness constraint 

[SCI-9817]: https://scinote.atlassian.net/browse/SCI-9817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ