### PR TITLE
(fix) The item card will refresh when the time field is not changed [SCI-10107]

### DIFF
--- a/app/javascript/vue/repository_item_sidebar/repository_values/date_time_component.vue
+++ b/app/javascript/vue/repository_item_sidebar/repository_values/date_time_component.vue
@@ -131,10 +131,16 @@ export default {
       this.endDate = date;
       if (!(this.endDate instanceof Date)) this.update();
     },
+    trimSecondsAndMilliseconds(date) {
+      return date.setSeconds(0, 0);
+    },
     validateValue() {
       this.error = null;
       // Date is not changed
-      if (this.defaultStartDate === this.startDate && this.defaultEndDate === this.endDate) return false;
+      if (this.trimSecondsAndMilliseconds(this.defaultStartDate) === this.trimSecondsAndMilliseconds(this.startDate)
+      && this.trimSecondsAndMilliseconds(this.defaultEndDate) === this.trimSecondsAndMilliseconds(this.endDate)) {
+        return false;
+      }
 
       if (this.range) {
         // Both empty


### PR DESCRIPTION

Jira ticket: [SCI-10107](https://scinote.atlassian.net/browse/SCI-10107)

### What was done
Previously the time was updated even when the user did not change it. That was because in the background the date object was always tracking (incrementing seconds and milliseconds) ensuring that two seemingly equal date objects would actually be different even when the user made no changes himself. Now we're trimming out the seconds and milliseconds from the comparison.

[SCI-10107]: https://scinote.atlassian.net/browse/SCI-10107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ