### PR TITLE
Load label templates and printers only when the print modal is shown [SCI-10155]

### DIFF
--- a/app/javascript/vue/repository_print_modal/container.vue
+++ b/app/javascript/vue/repository_print_modal/container.vue
@@ -1,6 +1,6 @@
 <template>
   <div ref="modal" class="modal fade" id="modal-print-repository-row-label" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
-    <div class="modal-dialog" role="document" data-e2e="e2e-MD-printLabel">
+    <div class="modal-dialog" role="document" data-e2e="e2e-MD-printLabel" v-if="showModal && fetchedPrintersAndTemplates">
       <div class="modal-content">
         <div v-if="availablePrinters.length > 0" class="printers-available">
           <div class="modal-header">
@@ -112,7 +112,8 @@ export default {
       copies: 1,
       zebraPrinters: null,
       labelTemplateError: null,
-      labelTemplateCode: null
+      labelTemplateCode: null,
+      fetchedPrintersAndTemplates: false
     };
   },
   components: {
@@ -120,13 +121,18 @@ export default {
     LabelPreview
   },
   mounted() {
-    $.get(this.urls.labelTemplates, (result) => {
-      this.templates = result.data;
-      this.selectDefaultLabelTemplate();
-    });
+    $(this.$refs.modal).on('show.bs.modal', () => {
+      if (!this.fetchedPrintersAndTemplates) {
+        $.get(this.urls.labelTemplates, (result) => {
+          this.templates = result.data;
+          this.selectDefaultLabelTemplate();
+        });
 
-    $.get(this.urls.printers, (result) => {
-      this.printers = result.data;
+        $.get(this.urls.printers, (result) => {
+          this.printers = result.data;
+        });
+        this.fetchedPrintersAndTemplates = true;
+      }
     });
 
     $(this.$refs.modal).on('hidden.bs.modal', () => {
@@ -163,7 +169,9 @@ export default {
       if (this.showModal) {
         this.initZebraPrinter();
         $(this.$refs.modal).modal('show');
-        this.validateTemplate();
+        if (!this.fetchedPrintersAndTemplates) {
+          this.validateTemplate();
+        }
       }
     },
     row_ids() {


### PR DESCRIPTION
Jira ticket: [SCI-10155](https://scinote.atlassian.net/browse/SCI-10155)

### What was done
_Load label templates and printers only when the print modal is shown and fix double validate template requests_

#### ToDo:
_N/A_

### Note:
_N/A_


[SCI-10155]: https://scinote.atlassian.net/browse/SCI-10155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ