### PR TITLE
(fix) Non decimal number in inventory table has commas [gl-SCI-10086]

### DIFF
--- a/app/assets/javascripts/repositories/renderers/view_renderers.js
+++ b/app/assets/javascripts/repositories/renderers/view_renderers.js
@@ -162,9 +162,9 @@ $.fn.dataTable.render.defaultRepositoryNumberValue = function() {
   return '';
 };
 
-$.fn.dataTable.render.RepositoryNumberValue = function(data) {
+$.fn.dataTable.render.RepositoryNumberValue = function (data) {
   return `<span class="number-value" data-value="${data.value}">
-            ${data.value.toLocaleString('en-US', { timeZone: 'UTC' })}
+            ${data.value}
           </span>`;
 };
 

--- a/app/javascript/vue/repository_item_sidebar/repository_values/RepositoryNumberValue.vue
+++ b/app/javascript/vue/repository_item_sidebar/repository_values/RepositoryNumberValue.vue
@@ -33,7 +33,7 @@
             'max-h-[4rem]': collapsed,
             'max-h-[40rem]': !collapsed
           }">
-      {{ colVal.toLocaleString('en-US', { timezone: 'UTC' }) }}
+      {{ colval }}
     </div>
     <div v-else
           class="text-sn-dark-grey font-inter text-sm font-normal leading-5">

--- a/app/serializers/repository_datatable/repository_number_value_serializer.rb
+++ b/app/serializers/repository_datatable/repository_number_value_serializer.rb
@@ -4,7 +4,7 @@ module RepositoryDatatable
   class RepositoryNumberValueSerializer < RepositoryBaseValueSerializer
     def value
       decimals = scope[:column].metadata.fetch('decimals', Constants::REPOSITORY_NUMBER_TYPE_DEFAULT_DECIMALS).to_i
-      value_object.data.round(value_object.data.scale.zero? ? 0 : decimals)
+      value_object.data.round(value_object.data.scale.zero? ? 0 : decimals).to_s
     end
   end
 end


### PR DESCRIPTION
Jira ticket: [SCI-10086](https://scinote.atlassian.net/browse/SCI-10086)

### What was done
Fixed the number formatting in tables and itemcard to not delimit thousands, but keep the decimal (dot) delimiter.


[SCI-10086]: https://scinote.atlassian.net/browse/SCI-10086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ