### PR TITLE
(fix) Add warning for unsaved changes when leaving Task workflow editmode (Canvas view) [SCI-10004]

### DIFF
--- a/app/assets/javascripts/projects/canvas.js.erb
+++ b/app/assets/javascripts/projects/canvas.js.erb
@@ -545,6 +545,35 @@ function bindTouchDropdowns(selector) {
   });
 }
 
+function handleAnchorClick(event) {
+  event.preventDefault();
+
+  // check if the clicked element is an anchor tag with an href
+  if (event.target.tagName === 'A' && event.target.href) {
+    const targetUrl = event.target.href;
+
+    const alertText = $("#update-canvas").attr("data-unsaved-work-text");
+    const exit = confirm(alertText);
+
+    if (exit) {
+      // remove unload listeners and navigate to location
+      $(window).off("beforeunload");
+      $(document).off("page:before-change");
+
+      window.location.href = targetUrl;
+    }
+  }
+};
+
+// listen to clicks on links in navigator and leftMenuContainer
+$(document).ready(function() {
+  const navigatorEl = $('.sci--layout-navigation-navigator');
+  const leftMenuContainerEl = $('.sci--layout--left-menu-container');
+
+  navigatorEl.on('click', 'a', handleAnchorClick);
+  leftMenuContainerEl.on('click', 'a', handleAnchorClick);
+});
+
 function bindEditModeCloseWindow() {
   var alertText = $("#update-canvas").attr("data-unsaved-work-text");
 


### PR DESCRIPTION
Jira ticket: [SCI-10004](https://scinote.atlassian.net/browse/SCI-10004)

### What was done
Added browser warnings when trying to navigate from task editmode to a link in navigator or left-most app sidebar.


[SCI-10004]: https://scinote.atlassian.net/browse/SCI-10004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ