### PR TITLE
(fix) CAPA - Tasks order in the reports widget is random [SCI-10334]

### DIFF
--- a/app/views/reports/wizard/_project_contents.html.erb
+++ b/app/views/reports/wizard/_project_contents.html.erb
@@ -22,7 +22,7 @@
         </div>
       </div>
       <ul class="experiment-contents collapse in" id="experimentContentContainer<%= experiment.id %>">
-        <% experiment.my_modules.viewable_by_user(current_user, current_team).active.sort_by { |m| @project_contents[:my_modules].index(m.id) || @project_contents[:my_modules].length if report }.each do |my_module| %>
+        <% experiment.my_modules.viewable_by_user(current_user, current_team).active.order(id: :asc).each do |my_module| %>
           <li class="experiment-my-module">
             <span class="sci-checkbox-container">
               <input type="checkbox" value="<%= my_module.id %>" class="sci-checkbox report-my-module-checkbox"


### PR DESCRIPTION
Jira ticket: [SCI-10334](https://scinote.atlassian.net/browse/SCI-10334)

### What was done
Fixed ordering of tasks in reports to ascending by id


[SCI-10334]: https://scinote.atlassian.net/browse/SCI-10334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ