### PR TITLE
(fix) Scinote is freezed at selecting time column in inventory filter [SCI-10278]

### DIFF
--- a/app/javascript/vue/repository_filter/mixins/filters/date_time_filter.js
+++ b/app/javascript/vue/repository_filter/mixins/filters/date_time_filter.js
@@ -82,6 +82,9 @@ export default {
       }
     },
     updateDate(date) {
+      if (this.date && date && (this.date.setSeconds(0, 0) === date.setSeconds(0, 0))) {
+        return;
+      }
       this.date = date;
       this.updateValue();
     },


### PR DESCRIPTION


Jira ticket: [SCI-10278](https://scinote.atlassian.net/browse/SCI-10278)

### What was done
Upon selecting a time filter the code entered into an infinite loop of updating this.date with an incoming date.
Solution was to specify an exit condition when the two dates are the same.
Important: for two dates to be the same they need to be sanitized (seconds and milliseconds need to be ignored).


[SCI-10278]: https://scinote.atlassian.net/browse/SCI-10278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ