### PR TITLE
Fix experiment carts sorting by number of completed tasks [SCI-10390]

### DIFF
--- a/app/javascript/vue/experiments/list.vue
+++ b/app/javascript/vue/experiments/list.vue
@@ -141,7 +141,7 @@ export default {
       }
 
       columns.push({
-        field: 'total_tasks',
+        field: 'completed_tasks',
         headerName: this.i18n.t('experiments.card.completed_task'),
         cellRenderer: CompletedTasksRenderer,
         sortable: true,

--- a/app/services/lists/experiments_service.rb
+++ b/app/services/lists/experiments_service.rb
@@ -77,7 +77,7 @@ module Lists
         code: 'experiments.id',
         archived_on: 'COALESCE(experiments.archived_on, projects.archived_on)',
         updated_at: 'experiments.updated_at',
-        total_tasks: 'task_count',
+        completed_tasks: 'completed_task_count',
         description: 'experiments.description'
       }
     end


### PR DESCRIPTION
Jira ticket: [SCI-10390](https://scinote.atlassian.net/browse/SCI-10390)

### What was done
Fix experiment carts sorting by number of completed tasks

[SCI-10390]: https://scinote.atlassian.net/browse/SCI-10390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ