### PR TITLE
Replace with new icon for column management on inventory page [SCI-10373]

### DIFF
--- a/app/views/repositories/_toolbar_buttons.html.erb
+++ b/app/views/repositories/_toolbar_buttons.html.erb
@@ -88,7 +88,7 @@
       <button class="btn btn-light btn-black icon-btn manage-repo-column-index" title="<%= t("libraries.manange_modal_column.button_tooltip") %>"
               data-modal-url="<%= repository_repository_columns_path(@repository) %>"
               data-action="new">
-        <span class="sn-icon sn-icon sn-icon-reports" data-e2e="e2e-BT-invInventoryRT-manageColumns">
+        <span class="sn-icon sn-icon-manage-columns" data-e2e="e2e-BT-invInventoryRT-manageColumns">
       </button>
     </div>
   </div>


### PR DESCRIPTION
Jira ticket: [SCI-10373](https://scinote.atlassian.net/browse/SCI-10373)

### What was done
_changed column management modal icon_



[SCI-10373]: https://scinote.atlassian.net/browse/SCI-10373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ