### PR TITLE
(fix) Check if there are any missing nonces in javascript_include_tags [SCI-10327]

### DIFF
--- a/app/views/protocols/index/_protocolsio_modal.html.erb
+++ b/app/views/protocols/index/_protocolsio_modal.html.erb
@@ -3,5 +3,5 @@
     <div class="modal-content"></div>
   </div>
 </div>
-<%= javascript_include_tag "protocols/steps" %>
-<%= javascript_include_tag "protocols/protocolsio" %>
+<%= javascript_include_tag "protocols/steps", nonce: true %>
+<%= javascript_include_tag "protocols/protocolsio", nonce: true %>


### PR DESCRIPTION
Jira ticket: [SCI-10327](https://scinote.atlassian.net/browse/SCI-10327)

### What was done
Added nonces to javascript_include_tags inside of partials where the partials are rendered via render_to_string call


[SCI-10327]: https://scinote.atlassian.net/browse/SCI-10327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ