### PR TITLE
(fix) TinyMCE toolbar breaks when inserting Text sections in collapsed Results [SCI-10233]

### DIFF
--- a/app/javascript/packs/tiny_mce.js
+++ b/app/javascript/packs/tiny_mce.js
@@ -326,6 +326,9 @@ window.TinyMCE = (() => {
             // Remove transition class
             $('.tox-editor-header').removeClass('tox-editor-dock-fadeout');
 
+            // Fixes the overflowing vertical controls bar for inserted text
+            $('.tox-editor-header').css('display', 'contents');
+
             // Init image toolbar
             initCssOverrides(editor);
 


### PR DESCRIPTION
…
Jira ticket: [SCI-10233](https://scinote.atlassian.net/browse/SCI-10233)

### What was done
fixed tox-editor-header vertical overflowing issue when creating a new text section in results


[SCI-10233]: https://scinote.atlassian.net/browse/SCI-10233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ