### PR TITLE
Inventory duplicating removes old inventory stock units [SCI-10251]

### DIFF
--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -240,7 +240,10 @@ class RepositoriesController < ApplicationController
       copied_repo_stock_column = copied_repository.repository_columns.find_by(data_type: 'RepositoryStockValue')
 
       if old_repo_stock_column && copied_repo_stock_column
-        copied_repo_stock_column.repository_stock_unit_items = old_repo_stock_column.repository_stock_unit_items
+        old_repo_stock_column.repository_stock_unit_items.each do |item|
+          copied_item = item.dup
+          copied_repo_stock_column.repository_stock_unit_items << copied_item
+        end
         copied_repository.save!
       end
 


### PR DESCRIPTION
Jira ticket: [SCI-10251](https://scinote.atlassian.net/browse/SCI-10251)

### What was done
_Fixed removing old inventory units upon copying_


[SCI-10251]: https://scinote.atlassian.net/browse/SCI-10251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ