### PR TITLE
Task name (Title) is always abbreviated on Task page - problems with task title row responsiveness [SCI-10259]

### DIFF
--- a/app/javascript/vue/protocol/container.vue
+++ b/app/javascript/vue/protocol/container.vue
@@ -5,7 +5,7 @@
         <div class="portocol-header-left-part grow">
           <template v-if="headerSticked && moduleName">
             <i class="sn-icon sn-icon-navigator sci--layout--navigator-open cursor-pointer p-1.5 border rounded border-sn-light-grey mr-4"></i>
-            <div @click="scrollTop" class="task-section-title w-[calc(100%_-_35rem)] min-w-[5rem] cursor-pointer">
+            <div @click="scrollTop" class="task-section-title w-[calc(100%_-_20rem)] min-w-[5rem] cursor-pointer" :title="moduleName">
               <h2 class="truncate leading-6">{{ moduleName }}</h2>
             </div>
           </template>
@@ -25,7 +25,7 @@
         </div>
       </div>
       <div class="actions-block">
-        <div class="protocol-buttons-group shrink-0">
+        <div class="protocol-buttons-group shrink-0 bg-sn-white">
           <a v-if="urls.add_step_url"
              class="btn btn-secondary"
              :title="i18n.t('protocols.steps.new_step_title')"

--- a/app/views/my_modules/_header.html.erb
+++ b/app/views/my_modules/_header.html.erb
@@ -1,10 +1,11 @@
 <div class="content-header my-module-header">
   <div class="my-module-title-row title-row">
     <i class="sn-icon sn-icon-navigator sci--layout--navigator-open cursor-pointer p-1.5 border rounded border-sn-light-grey mr-4"></i>
-    <h1 class="my_module-name" data-toggle="tooltip" data-placement="bottom" title="<%= @my_module.name %>">
+    <h1 class="my_module-name" data-toggle="tooltip" data-placement="bottom">
       <% if @my_module.archived_branch? %>
         <span class="whitespace-nowrap"><%= t('labels.archived')%></span>&nbsp;
       <% end %>
+      <div class="my_module-name-span" title="<%= @my_module.name %>">
       <% if @inline_editable_title_config.present? %>
               <%= render partial: "shared/inline_editing",
                          locals: {
@@ -16,6 +17,7 @@
           <%= @my_module.name %>
         </div>
       <% end %>
+      </div>
     </h1>
   </div>
 </div>


### PR DESCRIPTION
Jira ticket: [SCI-10259](https://scinote.atlassian.net/browse/SCI-10259)

### What was done
_styling improvements_


[SCI-10259]: https://scinote.atlassian.net/browse/SCI-10259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ