### PR TITLE
Inventory export for checklists with return delimiter should escape the return sign [SCI-10200]

### DIFF
--- a/app/models/repository_checklist_value.rb
+++ b/app/models/repository_checklist_value.rb
@@ -20,7 +20,7 @@ class RepositoryChecklistValue < ApplicationRecord
   EXTRA_PRELOAD_INCLUDE = :repository_checklist_items
 
   def formatted(separator: ' | ')
-    repository_checklist_items.pluck(:data).join(separator)
+    repository_checklist_items.pluck(:data).join(separator).gsub("\n", "\\n")
   end
 
   def export_formatted

--- a/app/services/spreadsheet_parser.rb
+++ b/app/services/spreadsheet_parser.rb
@@ -44,8 +44,8 @@ class SpreadsheetParser
       if row && i.zero?
         header = row
       else
-        escaped_row = row.map do |row|
-          row.gsub("\\n", "\n")
+        escaped_row = row.map do |cell|
+          cell.gsub("\\n", "\n")
         end
         columns = escaped_row
       end

--- a/app/services/spreadsheet_parser.rb
+++ b/app/services/spreadsheet_parser.rb
@@ -44,7 +44,10 @@ class SpreadsheetParser
       if row && i.zero?
         header = row
       else
-        columns = row
+        escaped_row = row.map do |row|
+          row.gsub("\\n", "\n")
+        end
+        columns = escaped_row
       end
     end
 


### PR DESCRIPTION
Jira ticket: [SCI-10200](https://scinote.atlassian.net/browse/SCI-10200)

### What was done
_handle escaping of checklists upon inventory row import and export_

[SCI-10200]: https://scinote.atlassian.net/browse/SCI-10200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ