### PR TITLE
Update omniauth-linkedin-oauth2 gem to 1.0.1 [SCI-10421]

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -470,7 +470,7 @@ GEM
       rack-protection
     omniauth-azure-activedirectory-v2 (2.0.1)
       omniauth-oauth2 (~> 1.8)
-    omniauth-linkedin-oauth2 (1.0.0)
+    omniauth-linkedin-oauth2 (1.0.1)
       omniauth-oauth2
     omniauth-oauth2 (1.8.0)
       oauth2 (>= 1.4, < 3)


### PR DESCRIPTION
Jira ticket: [SCI-10421](https://scinote.atlassian.net/browse/SCI-10421)

### What was done
Update omniauth-linkedin-oauth2 gem to 1.0.1