### PR TITLE
(fix) Assign to task - 'Type & Search' option not available [SCI-10382]

### DIFF
--- a/app/javascript/vue/assign_items_to_tasks_modal/container.vue
+++ b/app/javascript/vue/assign_items_to_tasks_modal/container.vue
@@ -41,6 +41,7 @@
             <SelectDropdown
               :value="selectedProject"
               ref="projectsSelector"
+              :searchable="true"
               @change="changeProject"
               :options="projects"
               :isLoading="projectsLoading"
@@ -69,6 +70,7 @@
             <SelectDropdown
               :value="selectedExperiment"
               :disabled="!selectedProject"
+              :searchable="true"
               ref="experimentsSelector"
               @change="changeExperiment"
               :options="experiments"
@@ -94,6 +96,7 @@
             <SelectDropdown
               :value="selectedTask"
               :disabled="!selectedExperiment"
+              :searchable="true"
               ref="tasksSelector"
               @change="changeTask"
               :options="tasks"


### PR DESCRIPTION
Jira ticket: [SCI-10382](https://scinote.atlassian.net/browse/SCI-10382)

### What was done
:searchable="true" prop was missing from the component


[SCI-10382]: https://scinote.atlassian.net/browse/SCI-10382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ