### PR TITLE
Wrong sorting icon on result page [SCI-10253]

### DIFF
--- a/app/javascript/vue/results/results_toolbar.vue
+++ b/app/javascript/vue/results/results_toolbar.vue
@@ -46,7 +46,7 @@
           :listItems="this.sortMenu"
           :btnClasses="'btn btn-light icon-btn'"
           :position="'right'"
-          :btnIcon="'sn-icon sn-icon-sort'"
+          :btnIcon="'sn-icon sn-icon-sort-down'"
           @sort="setSort"
         ></MenuDropdown>
     </div>


### PR DESCRIPTION
Jira ticket: [SCI-10253](https://scinote.atlassian.net/browse/SCI-10253)

### What was done
_changed sorting icon_


[SCI-10253]: https://scinote.atlassian.net/browse/SCI-10253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ