### PR TITLE
Hide last pinned column resizer on grid ready and columns reset [SCI-10441]

### DIFF
--- a/app/javascript/vue/shared/datatable/table.vue
+++ b/app/javascript/vue/shared/datatable/table.vue
@@ -543,6 +543,7 @@ export default {
         this.gridApi.sizeColumnsToFit();
         this.initializing = false;
       }
+      this.hideLastPinnedResizeCell();
     },
     onFirstDataRendered() {
       this.resize();
@@ -630,6 +631,7 @@ export default {
     resetColumnsToDefault() {
       this.columnApi.resetColumnState();
       this.gridApi.sizeColumnsToFit();
+      this.hideLastPinnedResizeCell();
     },
     getOrder(columnsState) {
       if (!columnsState) return null;


### PR DESCRIPTION
Jira ticket: [SCI-10441](https://scinote.atlassian.net/browse/SCI-10441)

### What was done
_Hide last pinned column resizer on grid ready and columns reset_

#### ToDo:
_N/A_

### Note:
_N/A_


[SCI-10441]: https://scinote.atlassian.net/browse/SCI-10441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ