### PR TITLE
Fix viewer role access for label template show page [SCI-10552]

### DIFF
--- a/app/serializers/lists/label_template_serializer.rb
+++ b/app/serializers/lists/label_template_serializer.rb
@@ -35,7 +35,7 @@ module Lists
     end
 
     def urls
-      return {} unless can_manage_label_templates?(object.team)
+      return {} unless can_view_label_templates?(object.team)
 
       {
         show: label_template_path(object)


### PR DESCRIPTION
Jira ticket: [SCI-10552](https://scinote.atlassian.net/browse/SCI-10552)

### What was done
_Fix viewer role access for label template show page_

#### ToDo:
_N/A_

### Note:
_N/A_


[SCI-10552]: https://scinote.atlassian.net/browse/SCI-10552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ