### PR TITLE
Make sure current_user is set earlier in asset syncs controller [SCI-10592]

### DIFF
--- a/app/controllers/asset_sync_controller.rb
+++ b/app/controllers/asset_sync_controller.rb
@@ -5,7 +5,7 @@ class AssetSyncController < ApplicationController
 
   skip_before_action :authenticate_user!, only: %i(update download)
   skip_before_action :verify_authenticity_token, only: %i(update download)
-  before_action :authenticate_asset_sync_token!, only: %i(update download)
+  prepend_before_action :authenticate_asset_sync_token!, only: %i(update download)
   before_action :check_asset_sync
 
   def show


### PR DESCRIPTION
Jira ticket: [SCI-10592](https://scinote.atlassian.net/browse/SCI-10592)

### What was done
Make sure current_user is set earlier in asset syncs controller, so it works properly as an override for authenticate_user!