### PR TITLE
Implement user settings cleanup job for Step deletion [SCI-10583]

### DIFF
--- a/app/jobs/cleanup_user_settings_job.rb
+++ b/app/jobs/cleanup_user_settings_job.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class CleanupUserSettingsJob < ApplicationJob
+  queue_as :default
+
+  def perform(record_type, record_id)
+    raise ArgumentError, 'Invalid record_type' unless %w(task_step_states results_order).include?(record_type)
+
+    sanitized_record_id = record_id.to_i.to_s
+    raise ArgumentError, 'Invalid record_id' unless sanitized_record_id == record_id.to_s
+
+    sql = <<-SQL.squish
+      UPDATE users
+      SET settings = (settings#>>'{}')::jsonb #- '{#{record_type},#{sanitized_record_id}}'
+      WHERE (settings#>>'{}')::jsonb->'#{record_type}' ? '#{sanitized_record_id}';
+    SQL
+
+    ActiveRecord::Base.connection.execute(sql)
+  end
+end

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -25,7 +25,7 @@ class Step < ApplicationRecord
   after_destroy :adjust_positions_after_destroy, unless: -> { skip_position_adjust }
 
   # conditional touch excluding step completion updates
-  after_destroy :touch_protocol
+  after_destroy :touch_protocol, :remove_from_user_settings
   after_save :touch_protocol
   after_touch :touch_protocol
 
@@ -188,6 +188,10 @@ class Step < ApplicationRecord
   end
 
   private
+
+  def remove_from_user_settings
+    CleanupUserSettingsJob.perform_later('task_step_states', id)
+  end
 
   def touch_protocol
     # if only step completion attributes were changed, do not touch protocol


### PR DESCRIPTION
Jira ticket: [SCI-10583](https://scinote.atlassian.net/browse/SCI-10583)

### What was done
- implement user settings cleanup job for Step deletion

### Note:
- for now the job deletes an id from the object at given key. In the future this job can be adapted to also take only the key for deletion and delete it in the user settings.
