### PR TITLE
Properly set warden session in asset syncs controller [SCI-10637]

### DIFF
--- a/app/controllers/asset_sync_controller.rb
+++ b/app/controllers/asset_sync_controller.rb
@@ -117,7 +117,8 @@ class AssetSyncController < ApplicationController
     render_error(:unauthorized) and return unless @asset_sync_token&.token_valid?
 
     @asset = @asset_sync_token.asset
-    @current_user = @asset_sync_token.user
+
+    sign_in(@asset_sync_token.user)
 
     render_error(:forbidden, @asset.file.filename) and return unless can_manage_asset?(@asset)
   end


### PR DESCRIPTION
Jira ticket: [SCI-10637](https://scinote.atlassian.net/browse/SCI-10637)

### What was done
Properly set warden session in asset syncs controller.

[SCI-10637]: https://scinote.atlassian.net/browse/SCI-10637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ