### PR TITLE
Comment column in task table is not sortable [SCI-10274]

### DIFF
--- a/app/javascript/vue/my_modules/list.vue
+++ b/app/javascript/vue/my_modules/list.vue
@@ -174,7 +174,7 @@ export default {
     columns.push({
       field: 'comments',
       headerName: this.i18n.t('experiments.table.column.comments_html'),
-      sortable: false,
+      sortable: true,
       cellRenderer: CommentsRenderer,
       notSelectable: true
     });

--- a/app/services/lists/my_modules_service.rb
+++ b/app/services/lists/my_modules_service.rb
@@ -49,7 +49,8 @@ module Lists
         designated: 'designated',
         results: 'results',
         tags: 'tags',
-        signatures: 'signatures'
+        signatures: 'signatures',
+        comments: 'comments'
       }
     end
 
@@ -107,6 +108,12 @@ module Lists
         @records = @records.left_joins(:tags)
                            .group('my_modules.id')
                            .order(Arel.sql('COUNT(DISTINCT tags.id) DESC'))
+      when  'comments_ASC'
+        @records = @records.left_joins(:task_comments).order(Arel.sql('COUNT(DISTINCT comments.id) ASC'))
+      when  'comments_DESC'
+        @records = @records.left_joins(:task_comments)
+                           .group('my_modules.id')
+                           .order(Arel.sql('COUNT(DISTINCT comments.id) DESC'))
       else
         __send__("#{sortable_columns[order_params[:column].to_sym]}_sort", sort_direction(order_params))
       end


### PR DESCRIPTION
Jira ticket: [SCI-10274](https://scinote.atlassian.net/browse/SCI-10274)

### What was done
_added comment sorting_


[SCI-10274]: https://scinote.atlassian.net/browse/SCI-10274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ