### PR TITLE
Remove name validation flash errors in inline-editing [SCI-10338]

### DIFF
--- a/app/assets/javascripts/shared/inline_editing.js
+++ b/app/assets/javascripts/shared/inline_editing.js
@@ -108,8 +108,10 @@ let inlineEditing = (function() {
         if (response.status === 403) {
           HelperModule.flashAlertMsg(I18n.t('general.no_permissions'), 'danger');
         } else if (response.status === 422) {
-          HelperModule.flashAlertMsg(response.responseJSON.errors
-            ? Object.values(response.responseJSON.errors).join(', ') : I18n.t('errors.general'), 'danger');
+          const errors = response.responseJSON.errors || response.responseJSON;
+          if (!errors) {
+            HelperModule.flashAlertMsg(I18n.t('errors.general'), 'danger');
+          }
         }
         if (!error) error = response.responseJSON.errors[fieldToUpdate];
         container.addClass('error');

--- a/app/controllers/experiments_controller.rb
+++ b/app/controllers/experiments_controller.rb
@@ -116,7 +116,7 @@ class ExperimentsController < ApplicationController
 
       render json: { message: t('experiments.update.success_flash', experiment: @experiment.name) }, status: :ok
     else
-      render json: { message: @experiment.errors.full_messages }, status: :unprocessable_entity
+      render json: { errors: @experiment.errors }, status: :unprocessable_entity
     end
   end
 


### PR DESCRIPTION
Jira ticket: [SCI-10338](https://scinote.atlassian.net/browse/SCI-10338)

### What was done
Remove name validation flash errors in inline-editing

[SCI-10338]: https://scinote.atlassian.net/browse/SCI-10338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ