### PR TITLE
Remove unneeded vips library require from team export job

### DIFF
--- a/app/jobs/team_zip_export_job.rb
+++ b/app/jobs/team_zip_export_job.rb
@@ -2,7 +2,6 @@
 
 require 'fileutils'
 require 'csv'
-require 'vips'
 
 # rubocop:disable Metrics/BlockLength
 class TeamZipExportJob < ZipExportJob


### PR DESCRIPTION
Remove unneeded vips library require from team export job