### PR TITLE
Disable eval for pdfjs [SCI-10680]

### DIFF
--- a/app/assets/javascripts/sitewide/pdf_preview.js
+++ b/app/assets/javascripts/sitewide/pdf_preview.js
@@ -115,7 +115,7 @@ var PdfPreview = (function() {
 
 
   function loadPdfDocument(canvas, page = 1) {
-    var loadingPdf = pdfjsLib.getDocument(canvas.dataset.pdfUrl);
+    var loadingPdf = pdfjsLib.getDocument({ url: canvas.dataset.pdfUrl, isEvalSupported: false });
     $(canvas).data('load-attempts', $(canvas).data('load-attempts') + 1);
     loadingPdf.promise
       .then(function(pdfDocument) {


### PR DESCRIPTION
Jira ticket: [SCI-10680](https://scinote.atlassian.net/browse/SCI-10680)

### What was done
Disable eval for pdfjs, due to: https://github.com/scinote-eln/scinote-web/security/dependabot/217

[SCI-10680]: https://scinote.atlassian.net/browse/SCI-10680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ