### PR TITLE
Fix order-by distinct mismatch in protocols list service [SCI-10688]

### DIFF
--- a/app/services/lists/protocols_service.rb
+++ b/app/services/lists/protocols_service.rb
@@ -14,7 +14,7 @@ module Lists
       published_versions = @raw_data
                            .in_repository_published_version
                            .order(:parent_id, version_number: :desc)
-                           .select('DISTINCT ON (parent_id) protocols.id')
+                           .select('DISTINCT ON (protocols.parent_id) protocols.id')
       new_drafts = @raw_data
                    .where(protocol_type: Protocol.protocol_types[:in_repository_draft], parent_id: nil)
                    .select('protocols.id')


### PR DESCRIPTION
Jira ticket: [SCI-10688](https://scinote.atlassian.net/browse/SCI-10688)

### What was done
Fix order-by distinct mismatch in protocols list service

[SCI-10688]: https://scinote.atlassian.net/browse/SCI-10688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ