### PR TITLE
(fix) No error message at create new task modal from canvas [SCI-10686]

### DIFF
--- a/app/assets/javascripts/experiments/show.js
+++ b/app/assets/javascripts/experiments/show.js
@@ -23,6 +23,23 @@
         }
       });
     });
+
+    $('#experiment-canvas').on('shown.bs.modal', () => {
+      // disable the submit button by default
+      $('#new-modal-submit-btn').prop('disabled', true);
+
+      // listen for input event on the my_module_name input field
+      $(`${newMyModuleModal} #my_module_name`).on('input', function () {
+        if ($(this).val().trim() !== '') {
+          // enable the submit button if the input field is populated
+          $('#new-modal-submit-btn').prop('disabled', false);
+        } else {
+          // otherwise, disable it
+          $('#new-modal-submit-btn').prop('disabled', true);
+        }
+      });
+    });
+
     // Modal's submit handler function
     $(experimentWrapper)
       .on('ajax:success', newMyModuleModal, function() {

--- a/app/views/my_modules/modals/_new_modal.html.erb
+++ b/app/views/my_modules/modals/_new_modal.html.erb
@@ -71,7 +71,7 @@
           <button type="button" class="btn btn-secondary" data-dismiss="modal">
             <%= t('general.cancel') %>
           </button>
-          <%= f.submit t('experiments.canvas.new_my_module_modal.create'), class: "btn btn-primary" %>
+          <%= f.submit t('experiments.canvas.new_my_module_modal.create'), class: "btn btn-primary", id: "new-modal-submit-btn" %>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Jira ticket: [SCI-10686](https://scinote.atlassian.net/browse/SCI-10686)

### What was done
Disabled the submit button by default. Enabling it when the input field is populated.


[SCI-10686]: https://scinote.atlassian.net/browse/SCI-10686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ