### PR TITLE
Fix task protocol status button data-e2e [SCI-10963]

### DIFF
--- a/app/views/my_modules/protocols/_protocol_status_bar.html.erb
+++ b/app/views/my_modules/protocols/_protocol_status_bar.html.erb
@@ -8,10 +8,10 @@
       [<%= t("my_modules.protocols.protocol_status_bar.unlinked") %>]
     </span>
   <% end %>
-  <a href="#" id="my-module-protocol-info-button" class="status-info dropdown-toggle data-e2e="e2e-BT-task-protocolInfo-openInfo"
+  <a href="#" id="my-module-protocol-info-button" class="status-info dropdown-toggle 
     <%= 'parent-newer' if @protocol.parent_newer? %>
     <%= 'protocol-newer' if @protocol.newer_than_parent? %>
-    " data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    " data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" data-e2e="e2e-BT-task-protocolInfo-openInfo">
     <i class="sn-icon sn-icon-info"></i>
   </a>
   <div class="dropdown-menu status-info-dropdown" aria-labelledby="my-module-protocol-info-button" data-e2e="e2e-CO-task-protocolInfo">


### PR DESCRIPTION
Jira ticket: [SCI-10963](https://scinote.atlassian.net/browse/SCI-10963)

#### What was done:
Fixed broken data-e2e attribute for task protocol status button.

[SCI-10963]: https://scinote.atlassian.net/browse/SCI-10963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ