### PR TITLE
Restrict ActiveStorage previews format to only PNG or JPEG [SCI-10969]

### DIFF
--- a/app/helpers/active_storage_helper.rb
+++ b/app/helpers/active_storage_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module ActiveStorageHelper
+  def image_preview_format(blob)
+    if ['image/jpeg', 'image/jpg'].include?(blob&.content_type)
+      :jpeg
+    else
+      :png
+    end
+  end
+end

--- a/app/jobs/active_storage/preview_job.rb
+++ b/app/jobs/active_storage/preview_job.rb
@@ -2,6 +2,8 @@
 
 # Provides asynchronous generation of image previews for ActiveStorage::Blob records.
 class ActiveStorage::PreviewJob < ActiveStorage::BaseJob
+  include ActiveStorageHelper
+
   queue_as :assets
 
   discard_on StandardError do |job, error|
@@ -18,11 +20,11 @@ class ActiveStorage::PreviewJob < ActiveStorage::BaseJob
 
   def perform(blob_id)
     blob = ActiveStorage::Blob.find(blob_id)
-    preview = blob.representation(resize_to_limit: Constants::MEDIUM_PIC_FORMAT).processed
+    preview = blob.representation(resize_to_limit: Constants::MEDIUM_PIC_FORMAT, format: image_preview_format(blob)).processed
     Rails.logger.info "Preview for the Blod with id: #{blob.id} - successfully generated.\n" \
                       "Transformations applied: #{preview.variation.transformations}"
 
-    preview = blob.representation(resize_to_limit: Constants::LARGE_PIC_FORMAT).processed
+    preview = blob.representation(resize_to_limit: Constants::LARGE_PIC_FORMAT, format: image_preview_format(blob)).processed
     Rails.logger.info "Preview for the Blod with id: #{blob.id} - successfully generated.\n" \
                       "Transformations applied: #{preview.variation.transformations}"
 

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -7,6 +7,7 @@ class Asset < ApplicationRecord
   include WopiUtil
   include ActiveStorageFileUtil
   include ActiveStorageConcerns
+  include ActiveStorageHelper
 
   require 'tempfile'
   # Lock duration set to 30 minutes
@@ -102,11 +103,11 @@ class Asset < ApplicationRecord
   end
 
   def medium_preview
-    preview_attachment.representation(resize_to_limit: Constants::MEDIUM_PIC_FORMAT)
+    preview_attachment.representation(resize_to_limit: Constants::MEDIUM_PIC_FORMAT, format: image_preview_format(blob))
   end
 
   def large_preview
-    preview_attachment.representation(resize_to_limit: Constants::LARGE_PIC_FORMAT)
+    preview_attachment.representation(resize_to_limit: Constants::LARGE_PIC_FORMAT, format: image_preview_format(blob))
   end
 
   def file_name

--- a/app/services/reports/utils.rb
+++ b/app/services/reports/utils.rb
@@ -11,9 +11,9 @@ module Reports
     def self.image_prepare(asset)
       if asset.class == Asset
         if asset.inline?
-          asset.preview_attachment.representation(resize_to_limit: Constants::MEDIUM_PIC_FORMAT, format: :png)
+          asset.medium_preview
         else
-          asset.preview_attachment.representation(resize_to_limit: Constants::LARGE_PIC_FORMAT, format: :png)
+          asset.large_preview
         end
       elsif asset.class == TinyMceAsset
         asset.image.representation(format: :png)


### PR DESCRIPTION
Jira ticket: [SCI-10969](https://scinote.atlassian.net/browse/SCI-10969)

### What was done
Restrict ActiveStorage previews format to only PNG or JPEG

[SCI-10969]: https://scinote.atlassian.net/browse/SCI-10969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ