### PR TITLE
Fix failed docx generation when you can not find image [SCI-11037]

### DIFF
--- a/app/services/reports/html_to_word_converter.rb
+++ b/app/services/reports/html_to_word_converter.rb
@@ -92,7 +92,19 @@ module Reports
         end
 
         if elem.name == 'img'
-          elements.push(img_element(elem))
+          begin
+            elements.push(img_element(elem))
+          rescue StandardError => e
+            Rails.logger.error e.message
+            Rails.logger.error(e.backtrace.join("\n"))
+
+            elements.push(
+              type: 'text',
+              value: I18n.t('projects.reports.index.generation.file_preview_generation_error'),
+              style: { italic: true }
+            )
+          end
+
           next
         end
 


### PR DESCRIPTION
Jira ticket: [SCI-11037](https://scinote.atlassian.net/browse/SCI-11037)

### What was done
Fix failes docx generation when you can not find image 

[SCI-11037]: https://scinote.atlassian.net/browse/SCI-11037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ