### PR TITLE
Fix shared location status display and breadcrumbs [SCI-11103]

### DIFF
--- a/app/controllers/storage_locations_controller.rb
+++ b/app/controllers/storage_locations_controller.rb
@@ -23,8 +23,13 @@ class StorageLocationsController < ApplicationController
       format.html
       format.json do
         storage_locations = Lists::StorageLocationsService.new(current_user, current_team, params).call
-        render json: storage_locations, each_serializer: Lists::StorageLocationSerializer,
-               user: current_user, meta: pagination_dict(storage_locations)
+        render json: storage_locations,
+               each_serializer: Lists::StorageLocationSerializer,
+               user: current_user,
+               meta: pagination_dict(storage_locations),
+               shared_object:
+                @parent_location &&
+                StorageLocation.select('*').select(StorageLocation.shared_sql_select(current_user)).find(@parent_location.root_storage_location.id)
       end
     end
   end

--- a/app/controllers/storage_locations_controller.rb
+++ b/app/controllers/storage_locations_controller.rb
@@ -225,7 +225,7 @@ class StorageLocationsController < ApplicationController
 
     storage_locations = []
     if params[:parent_id] || @storage_location
-      location = (current_team.storage_locations.find_by(id: params[:parent_id]) || @storage_location)
+      location = StorageLocation.find_by(id: params[:parent_id]) || @storage_location
       if location
         storage_locations.unshift(breadcrumbs_item(location))
         while location.parent

--- a/app/serializers/concerns/shareable_serializer.rb
+++ b/app/serializers/concerns/shareable_serializer.rb
@@ -8,11 +8,11 @@ module ShareableSerializer
   end
 
   def shared
-    object.shared_with?(current_user.current_team)
+    shared_object.shared_with?(current_user.current_team)
   end
 
   def shared_label
-    case object[:shared]
+    case shared_object[:shared]
     when 1
       I18n.t('libraries.index.shared')
     when 2
@@ -25,18 +25,24 @@ module ShareableSerializer
   end
 
   def ishared
-    object.i_shared?(current_user.current_team)
+    shared_object.i_shared?(current_user.current_team)
   end
 
   def shared_read
-    object.shared_read?
+    shared_object.shared_read?
   end
 
   def shared_write
-    object.shared_write?
+    shared_object.shared_write?
   end
 
   def shareable_write
-    object.shareable_write?
+    shared_object.shareable_write?
+  end
+
+  private
+
+  def shared_object
+    instance_options[:shared_object] || object
   end
 end


### PR DESCRIPTION
Jira ticket: [SCI-11103](https://scinote.atlassian.net/browse/SCI-11103)

### What was done
Fix storage location breadcrumbs for shared locations
Pass root location share status to child location serializer

[SCI-11103]: https://scinote.atlassian.net/browse/SCI-11103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ