### PR TITLE
Hide archived rows and repositories in storage locations assignment modal [SCI-11131]

### DIFF
--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -44,11 +44,12 @@ class RepositoriesController < ApplicationController
   end
 
   def list
-    results = @repositories
+    results = @repositories.select(:id, :name, 'LOWER(repositories.name)')
     results = results.name_like(params[:query]) if params[:query].present?
     results = results.joins(:repository_rows).distinct if params[:non_empty].present?
+    results = results.active if params[:active].present?
 
-    render json: { data: results.map { |r| [r.id, r.name] } }
+    render json: { data: results.order('LOWER(repositories.name) asc').map { |r| [r.id, r.name] } }
   end
 
   def rows_list
@@ -59,7 +60,9 @@ class RepositoriesController < ApplicationController
         params[:query]
       )
     end
-    render json: { data: results.map { |r| [r.id, r.name] } }
+    results = results.active if params[:active].present?
+
+    render json: { data: results.order('LOWER(repository_rows.name) asc').map { |r| [r.id, r.name] } }
   end
 
   def sidebar

--- a/app/javascript/vue/storage_locations/modals/assign/row_selector.vue
+++ b/app/javascript/vue/storage_locations/modals/assign/row_selector.vue
@@ -48,14 +48,14 @@ export default {
   },
   computed: {
     repositoriesUrl() {
-      return list_team_repositories_path(this.teamId, { non_empty: true });
+      return list_team_repositories_path(this.teamId, { non_empty: true, active: true });
     },
     rowsUrl() {
       if (!this.selectedRepository) {
         return null;
       }
 
-      return rows_list_team_repositories_path(this.teamId);
+      return rows_list_team_repositories_path(this.teamId, { active: true });
     }
   },
   data() {


### PR DESCRIPTION
Jira ticket: [SCI-11131](https://scinote.atlassian.net/browse/SCI-11131)

### What was done
This pull request includes changes to the `repositories_controller.rb` and a Vue component to enhance the filtering and ordering of repository and row data. The most important changes include adding an `active` filter to the repository and row queries and ensuring the results are ordered alphabetically.

Enhancements to filtering and ordering:

* [`app/controllers/repositories_controller.rb`](diffhunk://#diff-66530a88786f5345428d06c67d2d4014604b0800283d8b1efd32fd164254bdb7L47-R52): Added an `active` filter to the `list` and `rows_list` methods, and modified the rendering to order results alphabetically by name. [[1]](diffhunk://#diff-66530a88786f5345428d06c67d2d4014604b0800283d8b1efd32fd164254bdb7L47-R52) [[2]](diffhunk://#diff-66530a88786f5345428d06c67d2d4014604b0800283d8b1efd32fd164254bdb7L62-R65)
* [`app/javascript/vue/storage_locations/modals/assign/row_selector.vue`](diffhunk://#diff-76b57d29cd0c0f677ed8ae4cccbff093242fcda53dd832309a406a840a6f7195L51-R58): Updated the `repositoriesUrl` and `rowsUrl` computed properties to include the `active` filter in their query parameters
