### PR TITLE
Storage locations fix name ordering and move modal ordering [SCI-11133]

### DIFF
--- a/app/controllers/storage_locations_controller.rb
+++ b/app/controllers/storage_locations_controller.rb
@@ -253,7 +253,7 @@ class StorageLocationsController < ApplicationController
   end
 
   def storage_locations_recursive_builder(storage_locations)
-    storage_locations.map do |storage_location|
+    storage_locations.order('LOWER(storage_locations.name) ASC').map do |storage_location|
       {
         storage_location: storage_location,
         can_manage: (can_manage_storage_location?(storage_location) unless storage_location.parent_id),

--- a/app/services/lists/storage_locations_service.rb
+++ b/app/services/lists/storage_locations_service.rb
@@ -60,9 +60,9 @@ module Lists
         @records = @records.order(id: :asc)
       when 'code_DESC'
         @records = @records.order(id: :desc)
-      when 'name_ASC'
+      when 'name_hash_ASC'
         @records = @records.order(name: :asc)
-      when 'name_DESC'
+      when 'name_hash_DESC'
         @records = @records.order(name: :desc)
       when 'sub_location_count_ASC'
         @records = @records.order(sub_location_count: :asc)


### PR DESCRIPTION
Jira ticket: [SCI-11133](https://scinote.atlassian.net/browse/SCI-11133)

### What was done
This pull request includes changes to improve the sorting and ordering of storage locations within the application. The most important changes include modifying the sorting method for storage locations and updating the ordering logic in the recursive builder.

Improvements to sorting and ordering:

* [`app/controllers/storage_locations_controller.rb`](diffhunk://#diff-78f0317054f8d2627da21676b01d41004f5d1f45838abe6f1d76501be03af354L256-R256): Updated the `storage_locations_recursive_builder` method to order storage locations by name in ascending order using a case-insensitive comparison.
* [`app/services/lists/storage_locations_service.rb`](diffhunk://#diff-b7e21e86bb6da06982412d942f49cadc5c670bbea1177d5cf734be18d6747375L63-R65): Changed the sorting criteria from `name_ASC` and `name_DESC` to `name_hash_ASC` and `name_hash_DESC` to better reflect the sorting logic by name.


[SCI-11133]: https://scinote.atlassian.net/browse/SCI-11133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ