### PR TITLE
Change create by on location duplicate [SCI-11136]

### DIFF
--- a/app/controllers/storage_locations_controller.rb
+++ b/app/controllers/storage_locations_controller.rb
@@ -86,7 +86,7 @@ class StorageLocationsController < ApplicationController
 
   def duplicate
     ActiveRecord::Base.transaction do
-      new_storage_location = @storage_location.duplicate!
+      new_storage_location = @storage_location.duplicate!(current_user)
       if new_storage_location
         @storage_location = new_storage_location
         log_activity('storage_location_created')


### PR DESCRIPTION
Jira ticket: [SCI-11136](https://scinote.atlassian.net/browse/SCI-11136)

### What was done
This pull request includes updates to the `StorageLocation` model and its associated controller to ensure that the user who duplicates a storage location is tracked. The most important changes involve passing the current user through the duplication process and updating the relevant methods to handle this new parameter.

### Changes to `StorageLocation` model:

* [`app/models/storage_location.rb`](diffhunk://#diff-37ab22bc93106c02670f36bd2ff320ccdf3b852e1f3378e0c9a5f5c70d40f7f3L62-R69): Modified the `duplicate!` method to accept a `user` parameter and set the `created_by` attribute on the new storage location.
* [`app/models/storage_location.rb`](diffhunk://#diff-37ab22bc93106c02670f36bd2ff320ccdf3b852e1f3378e0c9a5f5c70d40f7f3L144-R152): Updated the `recursive_duplicate` method to propagate the `user` parameter and set the `created_by` attribute on recursively duplicated storage locations.

### Changes to `StorageLocation` controller:

* [`app/controllers/storage_locations_controller.rb`](diffhunk://#diff-78f0317054f8d2627da21676b01d41004f5d1f45838abe6f1d76501be03af354L89-R89): Updated the `duplicate` action to pass the `current_user` to the `duplicate!` method.


[SCI-11136]: https://scinote.atlassian.net/browse/SCI-11136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ