### PR TITLE
Add loading spinner for import export [SCI-11130]

### DIFF
--- a/app/javascript/vue/storage_locations/modals/import.vue
+++ b/app/javascript/vue/storage_locations/modals/import.vue
@@ -49,6 +49,10 @@
             {{ i18n.t('general.cancel') }}
           </button>
         </div>
+        <div v-if="loading" class="flex absolute top-0 left-0 items-center justify-center w-full flex-grow h-full z-10">
+          <div class="absolute top-0 left-0 w-full h-full bg-black opacity-20"></div>
+          <img src="/images/medium/loading.svg" alt="Loading" class="p-4 rounded-xl bg-sn-white relative z-10" />
+        </div>
       </div>
     </div>
   </div>
@@ -78,7 +82,8 @@ export default {
   },
   data() {
     return {
-      error: null
+      error: null,
+      loading: false
     };
   },
   computed: {
@@ -99,7 +104,7 @@ export default {
     },
     uploadFile(file) {
       const formData = new FormData();
-
+      this.loading = true;
       // required payload
       formData.append('file', file);
 
@@ -108,9 +113,11 @@ export default {
       })
         .then(() => {
           this.$emit('reloadTable');
+          this.loading = false;
           this.close();
         }).catch((error) => {
           this.handleError(error.response.data.message);
+          this.loading = false;
         });
     }
   }


### PR DESCRIPTION
Jira ticket: [SCI-11130](https://scinote.atlassian.net/browse/SCI-11130)

### What was done
This pull request includes changes to the `app/javascript/vue/storage_locations/modals/import.vue` file to improve user experience by adding a loading indicator during file uploads.

User experience improvements:

* Added a loading overlay and spinner to indicate when a file upload is in progress. (`app/javascript/vue/storage_locations/modals/import.vue`)
* Introduced a `loading` state to manage the display of the loading indicator. (`app/javascript/vue/storage_locations/modals/import.vue`) [[1]](diffhunk://#diff-59816e50c8bb3ccc1020598e8fa7ae883f320e8a0a6b408204849b4e5c892b8dL81-R86) [[2]](diffhunk://#diff-59816e50c8bb3ccc1020598e8fa7ae883f320e8a0a6b408204849b4e5c892b8dL102-R107) [[3]](diffhunk://#diff-59816e50c8bb3ccc1020598e8fa7ae883f320e8a0a6b408204849b4e5c892b8dR116-R120)

[SCI-11130]: https://scinote.atlassian.net/browse/SCI-11130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ