### PR TITLE
Fix split table state for storage containers [SCI-11138]

### DIFF
--- a/app/javascript/vue/storage_locations/container.vue
+++ b/app/javascript/vue/storage_locations/container.vue
@@ -11,7 +11,7 @@
     </div>
     <div class="h-full bg-white px-4">
       <DataTable :columnDefs="columnDefs"
-                tableId="StorageLocationsContainer"
+                :tableId="tableId"
                 :dataUrl="dataSource"
                 ref="table"
                 :reloadingTable="reloadingTable"
@@ -123,7 +123,9 @@ export default {
     paginationMode() {
       return this.withGrid ? 'none' : 'pages';
     },
-
+    tableId() {
+      return this.withGrid ? 'StorageLocationsContainerGrid' : 'StorageLocationsContainer';
+    },
     columnDefs() {
       let columns = [];
 

--- a/config/initializers/extends.rb
+++ b/config/initializers/extends.rb
@@ -696,6 +696,7 @@ class Extends
     Repositories_archived_state
     StorageLocationsTable_active_state
     StorageLocationsContainer_active_state
+    StorageLocationsContainerGrid_active_state
     task_step_states
     results_order
     repository_export_file_type


### PR DESCRIPTION
Jira ticket: [SCI-11138](https://scinote.atlassian.net/browse/SCI-11138)

### What was done
This pull request includes updates to the `StorageLocationsContainer` component and an initializer file to improve table ID handling and state management.

Changes to `StorageLocationsContainer` component:

* [`app/javascript/vue/storage_locations/container.vue`](diffhunk://#diff-21a3ae3c1e321f1524c01f9fa397525c84cd252b35f2f1054584f6238b491f28L14-R14): Modified the `tableId` property to be dynamic based on the `withGrid` condition. [[1]](diffhunk://#diff-21a3ae3c1e321f1524c01f9fa397525c84cd252b35f2f1054584f6238b491f28L14-R14) [[2]](diffhunk://#diff-21a3ae3c1e321f1524c01f9fa397525c84cd252b35f2f1054584f6238b491f28L126-R128)

Changes to state management:

* [`config/initializers/extends.rb`](diffhunk://#diff-06c9d344862ac8a9eaabe8a11949468afdcab073b9543676be7d2c14f4301476R699): Added a new state `StorageLocationsContainerGrid_active_state` to manage the grid view state.


[SCI-11138]: https://scinote.atlassian.net/browse/SCI-11138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ