### PR TITLE
Fix moving during locations filtering [SCI-11137]

### DIFF
--- a/app/javascript/vue/storage_locations/modals/move_tree_mixin.js
+++ b/app/javascript/vue/storage_locations/modals/move_tree_mixin.js
@@ -34,13 +34,13 @@ export default {
   },
   methods: {
     filteredStorageLocationsTreeHelper(storageLocationsTree) {
-      return storageLocationsTree.map(({ storage_location, children }) => {
+      return storageLocationsTree.map(({ storage_location, children, can_manage }) => {
         if (storage_location.name.toLowerCase().includes(this.query.toLowerCase())) {
-          return { storage_location, children };
+          return { storage_location, children, can_manage };
         }
 
         const filteredChildren = this.filteredStorageLocationsTreeHelper(children);
-        return filteredChildren.length ? { storage_location, children: filteredChildren } : null;
+        return filteredChildren.length ? { storage_location, can_manage, children: filteredChildren } : null;
       }).filter(Boolean);
     },
     selectStorageLocation(storageLocationId) {


### PR DESCRIPTION
Jira ticket: [SCI-11137](https://scinote.atlassian.net/browse/SCI-11137)

### What was done
This pull request includes a change to the `app/javascript/vue/storage_locations/modals/move_tree_mixin.js` file to enhance the filtering logic for storage locations. The key modification is the inclusion of the `can_manage` property in the `filteredStorageLocationsTreeHelper` method.

Enhancements to filtering logic:

* [`app/javascript/vue/storage_locations/modals/move_tree_mixin.js`](diffhunk://#diff-351a0e2dc2f811654339603396f904e21d4375435ca9aebdb68b4ef996b13a67L37-R43): Modified the `filteredStorageLocationsTreeHelper` method to include the `can_manage` property when mapping and filtering storage locations.

[SCI-11137]: https://scinote.atlassian.net/browse/SCI-11137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ