### PR TITLE
Fix position emit in row selection [SCI-11139]

### DIFF
--- a/app/javascript/vue/storage_locations/modals/assign/position_selector.vue
+++ b/app/javascript/vue/storage_locations/modals/assign/position_selector.vue
@@ -52,6 +52,7 @@ export default {
   watch: {
     selectedRow() {
       [[this.selectedColumn]] = this.availableColumns;
+      this.$emit('change', [this.selectedRow, this.selectedColumn]);
     },
     selectedColumn() {
       this.$emit('change', [this.selectedRow, this.selectedColumn]);


### PR DESCRIPTION
Jira ticket: [SCI-11139](https://scinote.atlassian.net/browse/SCI-11139)

### What was done
This pull request includes a small change to the `position_selector.vue` file. The change ensures that the `change` event is emitted with both `selectedRow` and `selectedColumn` whenever `selectedRow` is updated.

* [`app/javascript/vue/storage_locations/modals/assign/position_selector.vue`](diffhunk://#diff-668038e5f82c109dc55ad24d8b19cb1a10d098e659f55a5fff29e98b7d9709c7R55): Added an event emission for `change` with both `selectedRow` and `selectedColumn` in the `selectedRow` watcher.

[SCI-11139]: https://scinote.atlassian.net/browse/SCI-11139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ