### PR TITLE
Add storage refresh on item assignment [SCI-11140]

### DIFF
--- a/app/javascript/vue/repository_item_sidebar/locations.vue
+++ b/app/javascript/vue/repository_item_sidebar/locations.vue
@@ -38,7 +38,7 @@
         v-if="openAssignModal"
         assignMode="assign"
         :selectedRow="repositoryRow.id"
-        @close="openAssignModal = false; $emit('reloadRow')"
+        @close="openAssignModal = false; $emit('reloadRow'); reloadStorageLocations()"
       ></AssignModal>
       <ConfirmationModal
         :title="i18n.t('storage_locations.show.unassign_modal.title')"
@@ -86,6 +86,11 @@ export default {
       }
       return '';
     },
+    reloadStorageLocations() {
+      if (window.StorageLocationsContainer) {
+        window.StorageLocationsContainer.$refs.container.reloadingTable = true;
+      }
+    },
     numberToLetter(number) {
       return String.fromCharCode(96 + number);
     },
@@ -95,9 +100,7 @@ export default {
         axios.post(unassign_rows_storage_location_path({ id: locationId }), { ids: [rowId] })
           .then(() => {
             this.$emit('reloadRow');
-            if (window.StorageLocationsContainer) {
-              window.StorageLocationsContainer.$refs.container.reloadingTable = true;
-            }
+            this.reloadStorageLocations();
           });
       }
     }


### PR DESCRIPTION
Jira ticket: [SCI-11140](https://scinote.atlassian.net/browse/SCI-11140)

### What was done
This pull request includes changes to the `app/javascript/vue/repository_item_sidebar/locations.vue` file to improve the handling of storage location reloading. The most important changes include adding a new method to reload storage locations and updating event handling to use this new method.

Enhancements to storage location reloading:

* [`app/javascript/vue/repository_item_sidebar/locations.vue`](diffhunk://#diff-02808d18f83f132d0ddf84b8b0fe0898d30ccf994ecf40fdb348bd67b358314dR89-R93): Added a new method `reloadStorageLocations` to handle the reloading of storage locations.
* [`app/javascript/vue/repository_item_sidebar/locations.vue`](diffhunk://#diff-02808d18f83f132d0ddf84b8b0fe0898d30ccf994ecf40fdb348bd67b358314dL41-R41): Updated the `@close` event handler to call `reloadStorageLocations` in addition to reloading the row.
* [`app/javascript/vue/repository_item_sidebar/locations.vue`](diffhunk://#diff-02808d18f83f132d0ddf84b8b0fe0898d30ccf994ecf40fdb348bd67b358314dL98-R103): Refactored the unassign storage location logic to use the new `reloadStorageLocations` method.


[SCI-11140]: https://scinote.atlassian.net/browse/SCI-11140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ