### PR TITLE
Fix moving action for shared locations [SCI-11149]

### DIFF
--- a/app/controllers/storage_locations_controller.rb
+++ b/app/controllers/storage_locations_controller.rb
@@ -123,8 +123,17 @@ class StorageLocationsController < ApplicationController
   end
 
   def tree
-    records = StorageLocation.viewable_by_user(current_user, current_team).where(parent: nil, container: [false, params[:container] == 'true'])
-    render json: storage_locations_recursive_builder(records)
+    records = StorageLocation.viewable_by_user(current_user, current_team)
+                             .where(
+                               parent: nil,
+                               container: [false, params[:container] == 'true']
+                             )
+    records = records.where(team_id: params[:team_id]) if params[:team_id]
+
+    render json: {
+      locations: storage_locations_recursive_builder(records),
+      movable_to_root: params[:team_id] && current_team.id == params[:team_id].to_i
+    }
   end
 
   def available_positions

--- a/app/javascript/vue/storage_locations/modals/move.vue
+++ b/app/javascript/vue/storage_locations/modals/move.vue
@@ -25,9 +25,12 @@
               </div>
             </div>
             <div class="max-h-80 overflow-y-auto">
-              <div class="p-2 flex items-center gap-2 cursor-pointer text-sn-blue hover:bg-sn-super-light-grey"
-                    @click="selectStorageLocation(null)"
-                   :class="{'!bg-sn-super-light-blue': selectedStorageLocationId == null}">
+              <div class="p-2 flex items-center gap-2 "
+                   @click="selectStorageLocation(null)"
+                   :class="{
+                     '!bg-sn-super-light-blue': selectedStorageLocationId == null,
+                     'cursor-pointer text-sn-blue hover:bg-sn-super-light-grey': movableToRoot
+                   }">
                 <i class="sn-icon sn-icon-projects"></i>
                 {{ i18n.t('storage_locations.index.move_modal.search_header') }}
               </div>
@@ -63,11 +66,15 @@ export default {
     selectedObject: Array,
     moveToUrl: String
   },
+  created() {
+    this.teamId = this.selectedObject.team_id;
+  },
   mixins: [modalMixin, MoveTreeMixin],
   data() {
     return {
       selectedStorageLocationId: null,
       storageLocationsTree: [],
+      teamId: null,
       query: '',
       moveMode: 'locations'
     };

--- a/app/javascript/vue/storage_locations/modals/move_tree_mixin.js
+++ b/app/javascript/vue/storage_locations/modals/move_tree_mixin.js
@@ -6,14 +6,19 @@ import {
 
 export default {
   mounted() {
-    axios.get(this.storageLocationsTreeUrl).then((response) => {
-      this.storageLocationsTree = response.data;
+    axios.get(this.storageLocationsTreeUrl, { params: { team_id: this.teamId } }).then((response) => {
+      this.storageLocationsTree = response.data.locations;
+      this.movableToRoot = response.data.movable_to_root;
+      if (!this.movableToRoot) {
+        this.selectedStorageLocationId = -1;
+      }
       this.dataLoaded = true;
     });
   },
   data() {
     return {
       selectedStorageLocationId: null,
+      movableToRoot: false,
       storageLocationsTree: [],
       query: '',
       dataLoaded: false
@@ -46,6 +51,10 @@ export default {
       }).filter(Boolean);
     },
     selectStorageLocation(storageLocationId) {
+      if (!this.movableToRoot && storageLocationId === null) {
+        return;
+      }
+
       this.selectedStorageLocationId = storageLocationId;
     }
   }

--- a/app/models/storage_location.rb
+++ b/app/models/storage_location.rb
@@ -21,6 +21,7 @@ class StorageLocation < ApplicationRecord
   has_many :repository_rows, through: :storage_location_repository_rows
 
   validates :name, length: { maximum: Constants::NAME_MAX_LENGTH }
+  validate :parent_same_team, if: -> { parent.present? }
   validate :parent_validation, if: -> { parent.present? }
   validate :no_grid_options, if: -> { !container }
   validate :no_dimensions, if: -> { !with_grid? }
@@ -201,6 +202,10 @@ class StorageLocation < ApplicationRecord
 
   def no_grid_options
     errors.add(:metadata, I18n.t('activerecord.errors.models.storage_location.attributes.metadata.invalid')) if metadata['display_type'] || metadata['dimensions']
+  end
+
+  def parent_same_team
+    errors.add(:parent, I18n.t('activerecord.errors.models.storage_location.attributes.parent_storage_location_team')) if parent.team != team
   end
 
   def no_dimensions

--- a/app/serializers/lists/storage_location_serializer.rb
+++ b/app/serializers/lists/storage_location_serializer.rb
@@ -9,7 +9,7 @@ module Lists
 
     attributes :id, :code, :name, :container, :description, :owned_by, :created_by,
                :created_on, :urls, :metadata, :file_name, :sub_location_count, :is_empty,
-               :img_url, :sa_description, :name_hash
+               :img_url, :sa_description, :name_hash, :team_id
 
     def owned_by
       object['team_name']

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -265,6 +265,7 @@ en:
           not_uniq_repository_row: 'Inventory item already exists'
           attributes:
             parent_storage_location: "Storage location cannot be parent to itself"
+            parent_storage_location_team: "Parent storage location and storage location should belongs to the same team"
             parent_storage_location_child: "Storage location cannot be moved to it's child"
             metadata:
               invalid: 'Invalid metadata'


### PR DESCRIPTION
Jira ticket: [SCI-11149](https://scinote.atlassian.net/browse/SCI-11149)

### What was done
This pull request includes multiple changes across various files to enhance the functionality and validation of storage locations. The most important changes include updates to the `StorageLocation` model, controller, and associated Vue components to support team-specific filtering and validation.

### Model and Validation Enhancements:

* [`app/models/storage_location.rb`](diffhunk://#diff-37ab22bc93106c02670f36bd2ff320ccdf3b852e1f3378e0c9a5f5c70d40f7f3R24): Added a validation to ensure that a storage location's parent belongs to the same team (`parent_same_team`). [[1]](diffhunk://#diff-37ab22bc93106c02670f36bd2ff320ccdf3b852e1f3378e0c9a5f5c70d40f7f3R24) [[2]](diffhunk://#diff-37ab22bc93106c02670f36bd2ff320ccdf3b852e1f3378e0c9a5f5c70d40f7f3R207-R210)
* [`config/locales/en.yml`](diffhunk://#diff-44438ce218f5287c58d0017f965d888715635d94280669896f75841fbd7b4cd7R268): Added a new error message for the `parent_same_team` validation.

### Controller Updates:

* [`app/controllers/storage_locations_controller.rb`](diffhunk://#diff-78f0317054f8d2627da21676b01d41004f5d1f45838abe6f1d76501be03af354L126-R136): Modified the `tree` method to filter storage locations by `team_id` and return additional data indicating if moving to the root is allowed.

### Frontend Enhancements:

* [`app/javascript/vue/storage_locations/modals/move.vue`](diffhunk://#diff-bf010fd242cd222bae24f693b182c86702290428240c8023a896cc50db82e319L28-R33): Updated the component to handle the new `movableToRoot` property, ensuring the UI reflects whether moving to the root is allowed. [[1]](diffhunk://#diff-bf010fd242cd222bae24f693b182c86702290428240c8023a896cc50db82e319L28-R33) [[2]](diffhunk://#diff-bf010fd242cd222bae24f693b182c86702290428240c8023a896cc50db82e319R69-R77)
* [`app/javascript/vue/storage_locations/modals/move_tree_mixin.js`](diffhunk://#diff-351a0e2dc2f811654339603396f904e21d4375435ca9aebdb68b4ef996b13a67L9-R22): Modified the mixin to include `team_id` in the request parameters and handle the `movableToRoot` property in the response. [[1]](diffhunk://#diff-351a0e2dc2f811654339603396f904e21d4375435ca9aebdb68b4ef996b13a67L9-R22) [[2]](diffhunk://#diff-351a0e2dc2f811654339603396f904e21d4375435ca9aebdb68b4ef996b13a67R55-R58)

### Serializer Update:

* [`app/serializers/lists/storage_location_serializer.rb`](diffhunk://#diff-4dae3eb38cfcf837aab4de1fb92245336e1d54fdd4a66ae05ab9aa84cec621a9L12-R12): Added `team_id` to the list of serialized attributes.

[SCI-11149]: https://scinote.atlassian.net/browse/SCI-11149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ