### PR TITLE
Add position format validation [SCI-11152]

### DIFF
--- a/app/services/storage_locations/import_service.rb
+++ b/app/services/storage_locations/import_service.rb
@@ -4,6 +4,8 @@ require 'caxlsx'
 
 module StorageLocations
   class ImportService
+    class PositionNotValid < StandardError; end
+
     def initialize(storage_location, file, user)
       @storage_location = storage_location
       @assigned_count = 0
@@ -54,6 +56,8 @@ module StorageLocations
       { status: :ok, assigned_count: @assigned_count, unassigned_count: @unassigned_count, updated_count: @updated_count }
     rescue ActiveRecord::RecordNotFound, ActiveRecord::RecordInvalid
       { status: :error, message: @error_message }
+    rescue PositionNotValid
+      { status: :error, message: I18n.t('storage_locations.show.import_modal.errors.invalid_position') }
     end
 
     private
@@ -104,6 +108,8 @@ module StorageLocations
 
     def convert_position_letter_to_number(position)
       return unless position
+
+      raise PositionNotValid unless position.to_s.match?(/^[A-Z]\d+$/)
 
       column_letter = position[0]
       row_number = position[1..]


### PR DESCRIPTION
Jira ticket: [SCI-11152](https://scinote.atlassian.net/browse/SCI-11152)

### What was done
This pull request introduces error handling improvements to the `ImportService` class in the `StorageLocations` module. The main focus is on adding a custom error for invalid positions during the import process.

Error handling improvements:

* [`app/services/storage_locations/import_service.rb`](diffhunk://#diff-e5552bce2058d7759390d9e6c5e27bf3cf3965cece559d05ff370394f297cb38R7-R9): Added a custom `PositionNotValid` error class to handle invalid position errors during the import process.
* [`app/services/storage_locations/import_service.rb`](diffhunk://#diff-e5552bce2058d7759390d9e6c5e27bf3cf3965cece559d05ff370394f297cb38R60-R61): Updated the `import_items` method to rescue `PositionNotValid` errors and return a localized error message.
* [`app/services/storage_locations/import_service.rb`](diffhunk://#diff-e5552bce2058d7759390d9e6c5e27bf3cf3965cece559d05ff370394f297cb38R117-R118): Modified the `convert_position_letter_to_number` method to raise the `PositionNotValid` error when encountering a standard error.


[SCI-11152]: https://scinote.atlassian.net/browse/SCI-11152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ