### PR TITLE
Fix for storage locations import [SCI-11152]

### DIFF
--- a/app/services/storage_locations/import_service.rb
+++ b/app/services/storage_locations/import_service.rb
@@ -15,7 +15,7 @@ module StorageLocations
     end
 
     def import_items
-      @rows = SpreadsheetParser.spreadsheet_enumerator(@sheet).reject { |r| r.all?(&:blank?) }
+      @rows = SpreadsheetParser.spreadsheet_enumerator(@sheet).to_a
 
       # Check if the file has proper headers
       header = SpreadsheetParser.parse_row(@rows[0], @sheet)
@@ -73,6 +73,8 @@ module StorageLocations
           repository_row_id: (row[1].to_s.gsub('IT', '') if row[1].present?)
         }
       end
+
+      @rows.reject! { |r| r[:repository_row_id].blank? && r[:position].blank? }
     end
 
     def import_row!(row)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2709,7 +2709,7 @@ en:
       import_modal:
         import_button: 'Import items'
         title: "Import items to a box"
-        description: "Import items to a box allows for assigning items to a box and updating positions within a grid box. First, export the current box data to download a file listing the items already in the box. Then, edit the exported file to add or update the items you want to place in the box. When importing the file, ensure it includes the ‘Position’ and ‘Item ID’ columns for a successful import."
+        description: "Import items to a box allows for assigning items to a box and updating positions within a grid box. First, export the current box data to download a file listing the items already in the box. Then, edit the exported file to add or update the items you want to place in the box. When importing the file, ensure it includes the ‘Box position’ and ‘Item ID’ columns for a successful import."
         export: "Export"
         export_button: "Export current box"
         import: "Import"


### PR DESCRIPTION
Jira ticket: [SCI-11152](https://scinote.atlassian.net/browse/SCI-11152)

### What was done
This pull request includes several changes to improve the `StorageLocations::ImportService` and update the import modal description. The key changes involve refining the data import process and clarifying user instructions.

Improvements to data import process:

* [`app/services/storage_locations/import_service.rb`](diffhunk://#diff-e5552bce2058d7759390d9e6c5e27bf3cf3965cece559d05ff370394f297cb38L18-R18): Modified the `import_items` method to convert the enumerator to an array immediately, ensuring all rows are processed.
* [`app/services/storage_locations/import_service.rb`](diffhunk://#diff-e5552bce2058d7759390d9e6c5e27bf3cf3965cece559d05ff370394f297cb38R76-R77): Added a filter in the `parse_rows!` method to reject rows where both `repository_row_id` and `position` are blank, improving data integrity.

Updates to user instructions:

* [`config/locales/en.yml`](diffhunk://#diff-44438ce218f5287c58d0017f965d888715635d94280669896f75841fbd7b4cd7L2712-R2712): Updated the description in the import modal to clarify that the file should include the 'Box position' and 'Item ID' columns for a successful import.

[SCI-11152]: https://scinote.atlassian.net/browse/SCI-11152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ