### PR TITLE
Fix moving location to root [SCI-11149]

### DIFF
--- a/app/controllers/storage_locations_controller.rb
+++ b/app/controllers/storage_locations_controller.rb
@@ -107,7 +107,7 @@ class StorageLocationsController < ApplicationController
           StorageLocation.find(move_params[:destination_storage_location_id])
         end
 
-      render_403 and return unless can_manage_storage_location?(destination_storage_location)
+      render_403 and return if destination_storage_location && !can_manage_storage_location?(destination_storage_location)
 
       @storage_location.update!(parent: destination_storage_location)
 


### PR DESCRIPTION
Jira ticket: [SCI-11149](https://scinote.atlassian.net/browse/SCI-11149)

### What was done
This pull request includes a change to the `move` method in the `StorageLocationsController` to improve the authorization logic. The most important change is the modification of the condition that checks if the user can manage the destination storage location.

Authorization logic improvement:

* [`app/controllers/storage_locations_controller.rb`](diffhunk://#diff-78f0317054f8d2627da21676b01d41004f5d1f45838abe6f1d76501be03af354L110-R110): Updated the `move` method to render a 403 error only if the `destination_storage_location` exists and the user does not have permission to manage it.


[SCI-11149]: https://scinote.atlassian.net/browse/SCI-11149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ