### PR TITLE
Add option for enabling Aws::Rails::SesMailer for sending emails with AWS SDK [SCI-11207]

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -30,7 +30,7 @@ Rails.application.configure do
   }
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true
-  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.delivery_method = ENV['SMTP_USE_AWS_SES'] == 'true' ? :ses : :smtp
 
   config.action_mailer.smtp_settings = {
     address: Rails.application.secrets.mailer_address,


### PR DESCRIPTION
Jira ticket: [SCI-11207](https://scinote.atlassian.net/browse/SCI-11207)

### What was done
Add option for enabling Aws::Rails::SesMailer for sending emails with AWS SDK

[SCI-11207]: https://scinote.atlassian.net/browse/SCI-11207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ