### PR TITLE
Create snapshot provisioning immediately when the task is locked [SCI-11185]

### DIFF
--- a/app/models/my_module.rb
+++ b/app/models/my_module.rb
@@ -565,6 +565,12 @@ class MyModule < ApplicationRecord
 
     yield
 
+    if status_changing_direction == :forward
+      my_module_status.my_module_status_consequences.each do |consequence|
+        consequence.before_forward_call(self)
+      end
+    end
+
     if my_module_status.my_module_status_consequences.any?(&:runs_in_background?)
       MyModuleStatusConsequencesJob
         .perform_later(self, my_module_status.my_module_status_consequences.to_a, status_changing_direction)

--- a/app/models/my_module_status_consequence.rb
+++ b/app/models/my_module_status_consequence.rb
@@ -7,6 +7,8 @@ class MyModuleStatusConsequence < ApplicationRecord
 
   def backward(my_module); end
 
+  def before_forward_call(my_module); end
+
   def runs_in_background?
     false
   end

--- a/app/models/my_module_status_consequences/repository_snapshot.rb
+++ b/app/models/my_module_status_consequences/repository_snapshot.rb
@@ -6,9 +6,14 @@ module MyModuleStatusConsequences
       true
     end
 
-    def forward(my_module)
+    def before_forward_call(my_module)
       my_module.assigned_repositories.each do |repository|
-        repository_snapshot = ::RepositorySnapshot.create_preliminary!(repository, my_module)
+        ::RepositorySnapshot.create_preliminary!(repository, my_module)
+      end
+    end
+
+    def forward(my_module)
+      my_module.repository_snapshots.where(status: :provisioning).find_each do |repository_snapshot|
         service = Repositories::SnapshotProvisioningService.call(repository_snapshot: repository_snapshot)
 
         unless service.succeed?


### PR DESCRIPTION
Jira ticket: [SCI-11185](https://scinote.atlassian.net/browse/SCI-11185)

### What was done
Create snapshot provisioning immediately when the task is locked

[SCI-11185]: https://scinote.atlassian.net/browse/SCI-11185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ