### PR TITLE
Don't export protocol asset version metadata [SCI-11237]

### DIFF
--- a/app/utilities/protocols_exporter_v2.rb
+++ b/app/utilities/protocols_exporter_v2.rb
@@ -132,7 +132,7 @@ module ProtocolsExporterV2
       "<asset id=\"#{asset.id}\" guid=\"#{asset_guid}\" fileRef=\"#{asset_file_name}\">\n" \
       "<fileName>#{asset.file_name}</fileName>\n" \
       "<fileType>#{asset.content_type}</fileType>\n" \
-      "<fileMetadata><!--[CDATA[  #{asset.file.metadata.to_json}  ]]--></fileMetadata>\n" \
+      "<fileMetadata><!--[CDATA[  #{asset.file.metadata.except('version', 'restored_from_version').to_json}  ]]--></fileMetadata>\n" \
       "</asset>\n"
   end
 end


### PR DESCRIPTION
Jira ticket: [SCI-11237](https://scinote.atlassian.net/browse/SCI-11237)

### What was done
Don't export protocol asset version metadata

[SCI-11237]: https://scinote.atlassian.net/browse/SCI-11237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ