### PR TITLE
Fix opening of tags modal on canvas medium view [SCI-11257]

### DIFF
--- a/app/views/canvas/medium_zoom/_my_module.html.erb
+++ b/app/views/canvas/medium_zoom/_my_module.html.erb
@@ -10,7 +10,7 @@
   data-module-y="<%= my_module.y %>"
   data-module-conns="<%= construct_module_connections(my_module) %>">
 
-  <a class="edit-tags-link pull-right" data-remote="true" href="<%= my_module_tags_edit_url(my_module, format: :json) %>">
+  <a class="edit-tags-link pull-right" data-remote="true" href="<%= my_module_path(my_module, format: :json) %>">
     <%= render partial: "canvas/tags", locals: { my_module: my_module } %>
   </a>
 


### PR DESCRIPTION
Jira ticket: [SCI-11257](https://scinote.atlassian.net/browse/SCI-11257)

### What was done
Fix opening of tags modal on canvas medium view

[SCI-11257]: https://scinote.atlassian.net/browse/SCI-11257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ