### PR TITLE
Improve handling of empty uid params in omniauth auth responces [SCI-11312]

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -386,6 +386,8 @@ class User < ApplicationRecord
   end
 
   def self.from_omniauth(auth)
+    return nil unless auth.provider.present? && auth.uid.present?
+
     includes(:user_identities)
       .where(
         'user_identities.provider=? AND user_identities.uid=?',


### PR DESCRIPTION
Jira ticket: [SCI-11312](https://scinote.atlassian.net/browse/SCI-11312)

### What was done
Improve handling of empty uid params in omniauth auth responces

[SCI-11312]: https://scinote.atlassian.net/browse/SCI-11312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ