### PR TITLE
Don't touch project and experiment when marking comments as read [SCI-11334]

### DIFF
--- a/app/views/shared/comments/_comments_list.html.erb
+++ b/app/views/shared/comments/_comments_list.html.erb
@@ -4,4 +4,4 @@
              locals: { comment: comment, skip_header: user == comment.user } %>
   <% user = comment.user %>
 <% end %>
-<% comments.mark_as_seen_by(current_user, @commentable) %>
+<% comments.mark_as_seen_by(current_user) %>


### PR DESCRIPTION
Jira ticket: [SCI-11334](https://scinote.atlassian.net/browse/SCI-11334)

### What was done
Removed obsolete logic that bumped updated at for project and experiments when marking comments as read.
Fixed some linter stuff.

[SCI-11334]: https://scinote.atlassian.net/browse/SCI-11334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ