### PR TITLE
Make inventory text column links open in new tab [SCI-11428]

### DIFF
--- a/app/serializers/repository_datatable/repository_text_value_serializer.rb
+++ b/app/serializers/repository_datatable/repository_text_value_serializer.rb
@@ -9,7 +9,16 @@ module RepositoryDatatable
     def value
       @user = scope[:user]
       {
-        view: value_object.has_smart_annotation? ? custom_auto_link(value_object.data, simple_format: true, team: scope[:team]) : auto_link(sanitize_input(value_object.data)),
+        view:
+          if value_object.has_smart_annotation?
+            custom_auto_link(value_object.data, simple_format: true, team: scope[:team])
+          else
+            auto_link(
+              sanitize_input(value_object.data),
+              html: { target: '_blank' },
+              link: :urls
+            )
+          end,
         edit: value_object.data
       }
     end


### PR DESCRIPTION
Jira ticket: [SCI-11428](https://scinote.atlassian.net/browse/SCI-11428)

### What was done
Made the method used in serializer in line with custom_auto_link

[SCI-11428]: https://scinote.atlassian.net/browse/SCI-11428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ