### PR TITLE
Hide rearrange button, if not enough elements in step [SCI-11440]

### DIFF
--- a/app/javascript/vue/protocol/step.vue
+++ b/app/javascript/vue/protocol/step.vue
@@ -426,7 +426,7 @@
       },
       actionsMenu() {
         let menu = [];
-        if (this.urls.reorder_elements_url) {
+        if (this.urls.reorder_elements_url && this.elements.length > 1) {
           menu = menu.concat([{
             text: this.i18n.t('protocols.steps.options_dropdown.rearrange'),
             emit: 'reorder',


### PR DESCRIPTION
Jira ticket: [SCI-11440](https://scinote.atlassian.net/browse/SCI-11440)

### What was done
Hide rearrange button, if not enough elements in step 