### PR TITLE
Fix WOPI action URL generation for Word vs Excell, PowerPoint [SCI-11419]

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -299,13 +299,13 @@ class Asset < ApplicationRecord
 
       # Extract only the licenced user flag parameter
       is_licenced_user = ENV['WOPI_BUSINESS_USERS'] == 'true' && action_url.include?('IsLicensedUser=BUSINESS_USER')
-      action_url = action_url.split(/[\&\?]</).first + "?IsLicencedUser=#{is_licenced_user ? 1 : 0}&"
+      action_url = action_url.split(/<.*>/).first + "IsLicencedUser=#{is_licenced_user ? 1 : 0}"
 
       rest_url = Rails.application.routes.url_helpers.wopi_rest_endpoint_url(
         host: ENV['WOPI_ENDPOINT_URL'],
         id: id
       )
-      action_url += "WOPISrc=#{rest_url}"
+      action_url += "&WOPISrc=#{rest_url}"
       if with_tokens
         token = user.get_wopi_token
         action_url + "&access_token=#{token.token}"\


### PR DESCRIPTION
Jira ticket: [SCI-11419](https://scinote.atlassian.net/browse/SCI-11419)

### What was done
Fix WOPI action URL generation for Word vs Excell, PowerPoint, which have a different URL structure.