### PR TITLE
Fix positioning of 'Processing' element on legacy datatables [SCI-11548]

### DIFF
--- a/app/assets/stylesheets/shared/datatables.scss
+++ b/app/assets/stylesheets/shared/datatables.scss
@@ -36,3 +36,9 @@ table.dataTable.table--resizable-columns {
     }
   }
 }
+
+div.dataTables_wrapper div.dataTables_processing {
+  // This overrides default library behaviour, where the 'Processing' element
+  // can go off-screen on large tables due to top: 50% positioning.
+  top: 150px !important;
+}


### PR DESCRIPTION
Jira ticket: [SCI-11548](https://scinote.atlassian.net/browse/SCI-11548)

### What was done
Fix positioning of 'Processing' element on legacy datatables

[SCI-11548]: https://scinote.atlassian.net/browse/SCI-11548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ