### PR TITLE
(POC) Implement option of rendering smart annotations on frontend [SCI-11540]

### DIFF
--- a/app/assets/javascripts/repositories/renderers/view_renderers.js
+++ b/app/assets/javascripts/repositories/renderers/view_renderers.js
@@ -32,8 +32,10 @@ $.fn.dataTable.render.defaultRepositoryAssetValue = function() {
 };
 
 $.fn.dataTable.render.RepositoryTextValue = function(data) {
-  const text = $(`<span class="text-value [&>p]:mb-0">${data.value.view}</span>`);
+  const text = $(`<span class="text-value [&>p]:mb-0">${window.renderSmartAnnotations(data.value.view)}</span>`);
+
   text.attr('data-edit-value', data.value.edit);
+
   return text.prop('outerHTML');
 };
 

--- a/app/assets/javascripts/shared/smart_annotations.js
+++ b/app/assets/javascripts/shared/smart_annotations.js
@@ -1,0 +1,28 @@
+const escapeHtml = (unsafe) => (
+  unsafe.replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#039;')
+);
+
+window.renderSmartAnnotations = (text) => (
+  text.replace(/\[#(.*?)~(.*?)~(\d+)\]/g, (match, label, type) => {
+    const tag = encodeURIComponent(match.slice(1, -1));
+    const safeLabel = escapeHtml(label);
+    const safeType = escapeHtml(type);
+
+    switch (type) {
+      case 'rep_item':
+        return `<a class="sa-link record-info-link" href="/sa?tag=${tag}"><span class="sa-type">INV</span>${safeLabel}</a>`;
+      default:
+        return `<a class="sa-link" href="/sa?tag=${tag}" target="_blank"><span class="sa-type">${safeType}</span>${safeLabel}</a>`;
+    }
+  })
+);
+
+window.renderElementSmartAnnotations = (element) => {
+  element.innerHTML = window.renderSmartAnnotations(element.innerHTML);
+
+  return true;
+};

--- a/app/controllers/smart_annotations_controller.rb
+++ b/app/controllers/smart_annotations_controller.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class SmartAnnotationsController < ApplicationController
+  def redirect
+    redirect_to redirect_path
+  end
+
+  private
+
+  def resource
+    prefix = params[:tag].first
+
+    return unless prefix == '#'
+
+    _, resource_tag, resource_id = params[:tag][1..].split('~')
+
+    resource_class =
+      case resource_tag
+      when 'prj'
+        Project
+      when 'exp'
+        Experiment
+      when 'tsk'
+        MyModule
+      when 'rep_item'
+        RepositoryRow
+      end
+
+    @resource ||= resource_class.find(resource_id)
+  end
+
+  def redirect_path
+    case resource
+    when Project
+      project_path(resource)
+    when Experiment
+      my_modules_experiment_path(resource)
+    when MyModule
+      protocols_my_module_path(resource)
+    when RepositoryRow
+      repository_repository_row_path(resource.repository, resource)
+    end
+  end
+end

--- a/app/javascript/vue/experiments/modals/description.vue
+++ b/app/javascript/vue/experiments/modals/description.vue
@@ -11,7 +11,9 @@
           </h4>
         </div>
         <div class="modal-body">
-          <div class="[&_.atwho-user-container]:!whitespace-normal whitespace-pre-wrap" v-html="experiment.sa_description"></div>
+          <div ref="description" class="[&_.atwho-user-container]:!whitespace-normal whitespace-pre-wrap">
+            {{ experiment.description }}
+          </div>
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-primary" data-dismiss="modal">{{ i18n.t('general.close') }}</button>
@@ -31,5 +33,8 @@ export default {
     experiment: Object,
   },
   mixins: [modalMixin],
+  mounted() {
+    window.renderElementSmartAnnotations(this.$refs.description);
+  }
 };
 </script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,8 @@ Rails.application.routes.draw do
 
     root 'dashboards#show'
 
+    get '/sa', to: 'smart_annotations#redirect'
+
     resources :navigations, only: [] do
       collection do
         get :top_menu


### PR DESCRIPTION
Jira ticket: [SCI-11540](https://scinote.atlassian.net/browse/SCI-11540)

### What was done
(POC) Implement option of rendering smart annotations on frontend

There are two examples of use, one in legacy code and the other in a Vue component.

### TODO
Implement the user info tooltip (would also be done in SmartAnnotationsController, but with additional permission checks).

[SCI-11540]: https://scinote.atlassian.net/browse/SCI-11540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ