### PR TITLE
Set explicit format for global_constants javascript [SCI-11567]

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,7 +17,7 @@
     <% if ::NewRelic::Agent.instance.started? %>
       <%= ::NewRelic::Agent.browser_timing_header(controller.request.content_security_policy_nonce) %>
     <% end %>
-    <script src="<%= global_constants_path %>"></script>
+    <script src="<%= global_constants_path(format: :js) %>"></script>
 
     <%= javascript_include_tag 'jquery_bundle' %>
     <%= javascript_include_tag 'application_pack' %>

--- a/app/views/layouts/shareable_links.html.erb
+++ b/app/views/layouts/shareable_links.html.erb
@@ -5,7 +5,7 @@
     <meta data-hook="head-js">
     <title><%=t "head.title", title: (yield :head_title) %></title>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
-    <script src="<%= global_constants_path %>"></script>
+    <script src="<%= global_constants_path(format: :js) %>"></script>
 
     <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag 'bootstrap_pack', media: 'all' %>

--- a/app/views/layouts/sign_in_halt.html.erb
+++ b/app/views/layouts/sign_in_halt.html.erb
@@ -10,7 +10,7 @@
     <style media="all">
       html, body { height: 100%; min-height: 100%; }
     </style>
-    <script src="<%= global_constants_path %>"></script>
+    <script src="<%= global_constants_path(format: :js) %>"></script>
 
     <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag 'bootstrap_pack', media: 'all' %>


### PR DESCRIPTION
Jira ticket: [SCI-11567](https://scinote.atlassian.net/browse/SCI-11567)

### What was done
Set explicit format for global_constants javascript, to prevent Devise counting it as "navigational format".

[SCI-11567]: https://scinote.atlassian.net/browse/SCI-11567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ