### PR TITLE
Configure Rails to serve static files by default for production Docker builds [SCI-11588]

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -14,6 +14,7 @@ RUN \
 
 ENV APP_HOME /usr/src/app
 ENV RAILS_ENV=production
+ENV RAILS_SERVE_STATIC_FILES=true
 ENV GEM_HOME=$APP_HOME/vendor/bundle/ruby/3.2.0
 ENV PATH=$GEM_HOME/bin:/usr/share/nodejs/yarn/bin:$PATH
 ENV BUNDLE_APP_CONFIG=.bundle
@@ -102,6 +103,7 @@ RUN \
 
 ENV APP_HOME /usr/src/app
 ENV RAILS_ENV=production
+ENV RAILS_SERVE_STATIC_FILES=true
 ENV GEM_HOME=$APP_HOME/vendor/bundle/ruby/3.2.0
 ENV PATH=$GEM_HOME/bin:$PATH
 ENV BUNDLE_APP_CONFIG=.bundle


### PR DESCRIPTION
Jira ticket: [SCI-11588](https://scinote.atlassian.net/browse/SCI-11588)

### What was done
Configure Rails to serve static files by default for production Docker builds

[SCI-11588]: https://scinote.atlassian.net/browse/SCI-11588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ