### PR TITLE
Fix handling of ' in global search frontend [SCI-11597]

### DIFF
--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -2,12 +2,12 @@
 
 <div id="GlobalSearch" class="contents">
   <global_search
-    :query="'<%= @display_query %>'"
+    query="<%= @display_query %>"
     :search-url="'<%= search_path(format: :json) %>'"
     teams-url="<%= visible_teams_teams_path %>"
     users-url="<%= visible_users_teams_path %>"
     :single-team="<%= current_user.teams.count == 1 %>"
-    current-team="<%= current_team.id %>"
+    :current-team="<%= current_team.id %>"
   />
 </div>
 


### PR DESCRIPTION
Jira ticket: [SCI-11597](https://scinote.atlassian.net/browse/SCI-11597)

### What was done
Fix handling of ' in global search frontend

[SCI-11597]: https://scinote.atlassian.net/browse/SCI-11597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ