### PR TITLE
Remove perfect-scrollbar from Assign repository dropdown [SCI-11716]

### DIFF
--- a/app/views/my_modules/protocols.html.erb
+++ b/app/views/my_modules/protocols.html.erb
@@ -97,7 +97,7 @@
                 <span><%= t('my_modules.assigned_items.assign_from') %></span>
                 <span class="sn-icon sn-icon-down"></span>
               </a>
-              <ul class="dropdown-menu repositories-dropdown-menu perfect-scrollbar rounded !p-2.5 sn-shadow-menu-sm flex flex-col gap-[1px]" aria-labelledby="repositories-assign-button">
+              <ul class="dropdown-menu repositories-dropdown-menu rounded !p-2.5 sn-shadow-menu-sm flex flex-col gap-[1px]" aria-labelledby="repositories-assign-button">
               </ul>
             </div>
           <% end %>


### PR DESCRIPTION
Jira ticket: [SCI-11716](https://scinote.atlassian.net/browse/SCI-11716)

### What was done
Remove perfect-scrollbar from Assign repository dropdown

[SCI-11716]: https://scinote.atlassian.net/browse/SCI-11716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ