### PR TITLE
Bump nokogiri from 1.18.3 to 1.18.4 [SCI-11729]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ gem 'jbuilder' # JSON structures via a Builder-style DSL
 gem 'logging', '~> 2.0.0'
 gem 'mime-types', '~> 3.4'
 gem 'nested_form_fields'
-gem 'nokogiri', '~> 1.16.5' # HTML/XML parser
+gem 'nokogiri', '~> 1.18.4' # HTML/XML parser
 gem 'noticed'
 gem 'oj'
 gem 'rails_autolink', '~> 1.1', '>= 1.1.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -456,9 +456,9 @@ GEM
       net-protocol
     newrelic_rpm (9.14.0)
     nio4r (2.7.3)
-    nokogiri (1.16.8-arm64-darwin)
+    nokogiri (1.18.5-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.16.8-x86_64-linux)
+    nokogiri (1.18.5-x86_64-linux-gnu)
       racc (~> 1.4)
     noticed (1.6.3)
       http (>= 4.0.0)
@@ -831,7 +831,7 @@ DEPENDENCIES
   mime-types (~> 3.4)
   nested_form_fields
   newrelic_rpm
-  nokogiri (~> 1.16.5)
+  nokogiri (~> 1.18.4)
   noticed
   oj
   omniauth (~> 2.1)


### PR DESCRIPTION
Jira ticket: [SCI-11729](https://scinote.atlassian.net/browse/SCI-11729)

### What was done
Bump nokogiri from 1.18.3 to 1.18.4

[SCI-11729]: https://scinote.atlassian.net/browse/SCI-11729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ