### PR TITLE
Fix long file names in project export [SCI-11725]

### DIFF
--- a/app/jobs/team_zip_export_job.rb
+++ b/app/jobs/team_zip_export_job.rb
@@ -140,7 +140,10 @@ class TeamZipExportJob < ZipExportJob
   # Appends given suffix to file_name and then adds original extension
   def append_file_suffix(file_name, suffix)
     ext = File.extname(file_name)
-    File.basename(file_name, ext) + suffix + ext
+    base_name = File.basename(file_name, ext)
+    max_base_length = Constants::NAME_MAX_LENGTH - suffix.length - ext.length
+
+    "#{base_name[0, max_base_length]}#{suffix}#{ext}"
   end
 
   def create_archived_results_folder(result_path)


### PR DESCRIPTION
Jira ticket: [SCI-11725](https://scinote.atlassian.net/browse/SCI-11725)

### What was done
Fix long file names in project export

[SCI-11725]: https://scinote.atlassian.net/browse/SCI-11725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ