### PR TITLE
Fix z-index for overlay in repository edit mode [SCI-11744]

### DIFF
--- a/app/assets/stylesheets/repositories.scss
+++ b/app/assets/stylesheets/repositories.scss
@@ -475,7 +475,7 @@
     background: $color-white;
     color: $color-silver-chalice;
     display: none;
-    z-index: 1;
+    z-index: 10;
 
     .repository-save-changes-link {
       cursor: pointer;


### PR DESCRIPTION
Jira ticket: [SCI-11744](https://scinote.atlassian.net/browse/SCI-11744)

### What was done
Fix z-index for overlay in repository edit mode


[SCI-11744]: https://scinote.atlassian.net/browse/SCI-11744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ