### PR TITLE
Default start time to midnight for datepicker [SCI-11827]

### DIFF
--- a/app/javascript/vue/shared/date_time_picker.vue
+++ b/app/javascript/vue/shared/date_time_picker.vue
@@ -18,6 +18,7 @@
       :auto-apply="true"
       :partial-flow="true"
       :markers="markers"
+      :start-time="{ hours: 0, minutes: 0, seconds: 0 }"
       week-start="0"
       :enable-time-picker="mode == 'datetime'"
       :time-picker="mode == 'time'"


### PR DESCRIPTION
Jira ticket: [SCI-11827](https://scinote.atlassian.net/browse/SCI-11827)

### What was done
Default start time to midnight for datepicker

[SCI-11827]: https://scinote.atlassian.net/browse/SCI-11827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ