### PR TITLE
Add an option to include serialized activity subject in a webhook [SCI-11910]

### DIFF
--- a/app/controllers/users/settings/webhooks_controller.rb
+++ b/app/controllers/users/settings/webhooks_controller.rb
@@ -72,7 +72,7 @@ module Users
       end
 
       def webhook_params
-        params.require(:webhook).permit(:http_method, :url, :active, :secret_key)
+        params.require(:webhook).permit(:http_method, :url, :active, :secret_key, :include_serialized_subject)
       end
 
       def load_filter_elements(filter)

--- a/app/services/activities/activity_webhook_service.rb
+++ b/app/services/activities/activity_webhook_service.rb
@@ -15,14 +15,29 @@ module Activities
       @activity.values.merge(
         type: @activity.type_of,
         created_at: @activity.created_at,
-        subject: {
-          type: @activity.subject_type,
-          id: @activity.subject_id
-        },
+        subject: serialized_subject,
         subject_breadcrumbs: @activity.subject_parents.map do |subject|
           { type: subject.model_name.human.downcase, id: subject.id }
         end
       )
+    end
+
+    private
+
+    def serialized_subject
+      return { type: @activity.subject_type, id: @activity.subject_id } unless @webhook.include_serialized_subject
+
+      serializer_name = Extends::ACTIVITY_SUBJECT_TYPE_API_SERIALIZER_MAP[@activity.subject_type]
+
+      unless serializer_name
+        return {
+          type: @activity.subject_type,
+          id: @activity.subject_id,
+          error: I18n.t('api.webhooks.errors.subject_not_serializable')
+        }
+      end
+
+      serializer_name.constantize.new(@activity.subject).as_json
     end
   end
 end

--- a/app/views/users/settings/webhooks/_webhook_form.html.erb
+++ b/app/views/users/settings/webhooks/_webhook_form.html.erb
@@ -17,6 +17,16 @@
   <% end %>
 </div>
 <div class="webhook-form-row">
+  <span class="form-text"><%= t("webhooks.index.include_serialized_subject") %></span>
+  <div class="sci-input-container form-group">
+    <span class="sci-checkbox-container ml-3">
+      <input type="checkbox" class="sci-checkbox" name="webhook[include_serialized_subject]" <%= 'checked' if f.object.include_serialized_subject %>/>
+      <span class="sci-checkbox-label"></span>
+    </span>
+    <small><%= t("webhooks.index.include_serialized_subject_hint") %></small>
+  </div>
+</div>
+<div class="webhook-form-row">
   <span class="form-text  webhook-form-secret-key-text"><%= t("webhooks.index.secret_key") %></span>
   <div class="webhook-secret-key-container">
     <div class="sci-input-container form-group">

--- a/config/initializers/extends.rb
+++ b/config/initializers/extends.rb
@@ -201,6 +201,24 @@ class Extends
     ProjectFolder Asset Step LabelTemplate StorageLocation StorageLocationRepositoryRow Form
   ).freeze
 
+  ACTIVITY_SUBJECT_TYPE_API_SERIALIZER_MAP = {
+    'Team' => 'Api::V1::TeamSerializer',
+    'RepositoryBase' => 'Api::V1::InventorySerializer',
+    'Project' => 'Api::V1::ProjectSerializer',
+    'Experiment' => 'Api::V1::ExperimentSerializer',
+    'MyModule' => 'Api::V1::TaskSerializer',
+    'Result' => 'Api::V2::ResultSerializer',
+    'Protocol' => 'Api::V1::ProtocolSerializer',
+    'Report' => 'Api::V1::ReportSerializer',
+    'RepositoryRow' => 'Api::V1::InventoryItemSerializer',
+    'ProjectFolder' => 'Api::V1::ProjectFolderSerializer',
+    'Asset' => 'Api::V2::AssetSerializer',
+    'Step' => 'Api::V2::StepSerializer',
+    'LabelTemplate' => 'Api::V1::LabelTemplateSerializer',
+    'StorageLocation' => 'Api::V1::StorageLocationSerializer',
+    'Form' => 'Api::V2::FormSerialize'
+  }
+
   SEARCHABLE_ACTIVITY_SUBJECT_TYPES = %w(
     RepositoryBase RepositoryRow Project Experiment MyModule Result Protocol Step Report
   ).freeze

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4599,6 +4599,8 @@ en:
       webhook_updated: "Webhook successfully updated"
       webhook_deleted: "Webhook successfully deleted"
       delete_webhook_confimration: "Are you sure you want to delete the webhook?"
+      include_serialized_subject: "Include serialized subject"
+      include_serialized_subject_hint: "(Optional) Include the full webhook subject info, using API serializers"
       secret_key: "Secret key"
       secret_key_hint: "(Optional) A secret key that will be included in the Webhook-Secret-Key header, for authentication purposes."
   # This section contains general words that can be used in any parts of
@@ -4727,6 +4729,9 @@ en:
       all_options_placeholder: 'All options selected'
       no_options_placeholder: 'No options found'
   api:
+    webhooks:
+      errors:
+        subject_not_serializable: "Subject not serializable."
     core:
       status_ok: "Ok"
       invalid_api_key: "API key is invalid or expired"

--- a/db/migrate/20250522104614_add_include_serialized_subject_to_webhooks.rb
+++ b/db/migrate/20250522104614_add_include_serialized_subject_to_webhooks.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddIncludeSerializedSubjectToWebhooks < ActiveRecord::Migration[7.0]
+  def change
+    add_column :webhooks, :include_serialized_subject, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_04_10_124417) do
+ActiveRecord::Schema[7.0].define(version: 2025_05_22_104614) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "pg_trgm"
@@ -1470,6 +1470,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_04_10_124417) do
     t.text "last_error"
     t.text "text"
     t.string "secret_key"
+    t.boolean "include_serialized_subject", default: false, null: false
     t.index ["activity_filter_id"], name: "index_webhooks_on_activity_filter_id"
   end
 


### PR DESCRIPTION


Jira ticket: [SCI-11910](https://scinote.atlassian.net/browse/SCI-11910)

### What was done
Add an option to include serialized activity subject in a webhook

[SCI-11910]: https://scinote.atlassian.net/browse/SCI-11910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ