### PR TITLE
Install puppeteer directly during docker build [SCI-11976]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get update -qq && \
 
 ENV PATH=/usr/share/nodejs/yarn/bin:$PATH
 
-RUN yarn install
+RUN yarn add npm:puppeteer-core@24.10.0
 
 ENV BUNDLE_PATH /usr/local/bundle/
 

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -85,7 +85,7 @@ RUN \
   yarnpkg && \
   wget -O $TIKA_PATH $TIKA_DIST_URL && \
   chmod +x $TIKA_PATH && \
-  /usr/share/nodejs/yarn/bin/yarn install && \
+  /usr/share/nodejs/yarn/bin/yarn add npm:puppeteer-core@24.10.0 && \
   apt-get install -y libreoffice && \
   ln -s /usr/lib/x86_64-linux-gnu/libvips.so.42 /usr/lib/x86_64-linux-gnu/libvips.so
 


### PR DESCRIPTION
Jira ticket: [SCI-11976](https://scinote.atlassian.net/browse/SCI-11976)

### What was done
Install puppeteer directly during docker build

[SCI-11976]: https://scinote.atlassian.net/browse/SCI-11976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ