### PR TITLE
Fix result and task protocol search (caused by upgrade to Rails 7.2) [SCI-12033]

### DIFF
--- a/app/models/protocol.rb
+++ b/app/models/protocol.rb
@@ -260,7 +260,7 @@ class Protocol < ApplicationRecord
 
   def self.viewable_by_user_my_module_protocols(user, teams)
     distinct.joins(:my_module)
-            .where(my_modules: MyModule.viewable_by_user(user, teams))
+            .where(my_modules: { id: MyModule.viewable_by_user(user, teams).select(:id) })
   end
 
   def self.filter_by_teams(teams = [])

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -52,8 +52,12 @@ class Result < ApplicationRecord
     teams = options[:teams] || current_team || user.teams.select(:id)
 
     new_query = joins(:my_module)
-                .where(my_modules: MyModule.with_granted_permissions(user, MyModulePermissions::READ)
-                                           .where(user_assignments: { team: teams }))
+                .where(
+                  my_modules: {
+                    id: MyModule.with_granted_permissions(user, MyModulePermissions::READ)
+                                .where(user_assignments: { team: teams }).select(:id)
+                  }
+                )
 
     unless include_archived
       new_query = new_query.joins(my_module: { experiment: :project })


### PR DESCRIPTION
Jira ticket: [SCI-12033](https://scinote.atlassian.net/browse/SCI-12033)

### What was done
Caused by: https://github.com/rails/rails/issues/53849
In Rails 7.2, an activerecord query written as:
```
Result.joins(:my_module).where(my_modules: MyModule.last(10))
```
No longer works. We need to either use singular `my_module:` , or specify the column, like `my_modules: { id: ....`

[SCI-12033]: https://scinote.atlassian.net/browse/SCI-12033?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ