### PR TITLE
Remove FileUrl from CheckFileInfo WOPI endpoint due to improper handling in their tests [SCI-12071]

### DIFF
--- a/app/controllers/wopi_controller.rb
+++ b/app/controllers/wopi_controller.rb
@@ -88,8 +88,6 @@ class WopiController < ActionController::Base
       BreadcrumbFolderUrl: @breadcrumb_folder_url
     }
 
-    msg[:FileUrl] = @asset.file.blob.url if @asset.file_size.positive?
-
     response.headers['X-WOPI-HostEndpoint'] = ENV['WOPI_ENDPOINT_URL']
     response.headers['X-WOPI-MachineName'] = ENV['WOPI_ENDPOINT_URL']
     response.headers['X-WOPI-ServerVersion'] = Scinote::Application::VERSION


### PR DESCRIPTION
Jira ticket: [SCI-12071](https://scinote.atlassian.net/browse/SCI-12071)

### What was done
Remove FileUrl from CheckFileInfo WOPI endpoint due to improper handling in their tests

[SCI-12071]: https://scinote.atlassian.net/browse/SCI-12071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ