### PR TITLE
Render icon instead of text for shared task step-result links [SCI-12106]

### DIFF
--- a/app/views/shareable_links/my_modules/results/_result.html.erb
+++ b/app/views/shareable_links/my_modules/results/_result.html.erb
@@ -14,7 +14,7 @@
             <button class="btn btn-light icon-btn dropdown-toggle"
                     type="button" id="StepsMenuDropdown<%= result.id %>"
                     data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-              <%= t('my_modules.results.link_to_step') %>
+              <i class="sn-icon sn-icon-steps"></i>
               <span class="absolute top-1 -right-1 h-4 min-w-4 bg-sn-science-blue text-white flex items-center justify-center rounded-full text-[10px]">
                 <%= result.steps.size %>
               </span>


### PR DESCRIPTION
Jira ticket: [SCI-12106](https://scinote.atlassian.net/browse/SCI-12106)

### What was done
Render icon instead of text for shared task step-result links

[SCI-12106]: https://scinote.atlassian.net/browse/SCI-12106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ