### PR TITLE
Fix queries in group unassignment job after upgrade to Rails 7.2 [SCI-12113]

### DIFF
--- a/app/jobs/user_assignments/project_group_un_assignment_job.rb
+++ b/app/jobs/user_assignments/project_group_un_assignment_job.rb
@@ -18,7 +18,7 @@ module UserAssignments
     def remove_users_from_experiments(project, users)
       experiments = project.experiments.joins(:user_assignments).where(user_assignments: { user: users })
       # rubocop:disable Rails/SkipsModelValidations
-      UserAssignment.where(assignable_type: 'Experiment', assignable_id: experiments, user: users).delete_all
+      UserAssignment.where(assignable_type: 'Experiment', assignable_id: experiments.select(:id), user: users).delete_all
       experiments.update_all(updated_at: Time.current)
       # rubocop:enable Rails/SkipsModelValidations
     end
@@ -26,10 +26,10 @@ module UserAssignments
     def remove_users_from_my_modules(project, users)
       my_modules = MyModule.joins(:user_assignments, experiment: :project)
                            .where(user_assignments: { user: users })
-                           .where(projects: project)
+                           .where(projects: { id: project.id })
       # rubocop:disable Rails/SkipsModelValidations
-      UserMyModule.where(user: users, my_module: my_modules).delete_all # remove designated users
-      UserAssignment.where(assignable_type: 'MyModule', assignable_id: my_modules, user: users).delete_all
+      UserMyModule.where(user: users, my_module_id:  my_modules.select(:id)).delete_all # remove designated users
+      UserAssignment.where(assignable_type: 'MyModule', assignable_id: my_modules.select(:id), user: users).delete_all
       my_modules.update_all(updated_at: Time.current)
       # rubocop:enable Rails/SkipsModelValidations
     end


### PR DESCRIPTION
Jira ticket: [SCI-12113](https://scinote.atlassian.net/browse/SCI-12113)

### What was done
Fix queries in group unassignment job after upgrade to Rails 7.2

`.where(projects: project)` is no longer valid, for example.

[SCI-12113]: https://scinote.atlassian.net/browse/SCI-12113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ