### PR TITLE
Set a correct event type on sign in after successful password reset [SCI-12135]

### DIFF
--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -25,7 +25,7 @@ class Users::PasswordsController < Devise::PasswordsController
         flash_message = resource.active_for_authentication? ? :updated : :updated_not_active
         set_flash_message!(:notice, flash_message)
         resource.after_database_authentication if check_database_authentication?(resource)
-        sign_in(resource_name, resource)
+        sign_in(resource_name, resource, event: :authentication)
       else
         set_flash_message!(:notice, :updated_not_active)
       end


### PR DESCRIPTION
Jira ticket: [SCI-12135](https://scinote.atlassian.net/browse/SCI-12135)

### What was done
Set a correct event type on sign in after successful password reset

[SCI-12135]: https://scinote.atlassian.net/browse/SCI-12135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ