### PR TITLE
Update Tika to 3.2.2 [SCI-12340]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:3.3-bookworm
 MAINTAINER SciNote <info@scinote.net>
 
-ARG TIKA_DIST_URL="https://dlcdn.apache.org/tika/2.9.4/tika-app-2.9.4.jar"
+ARG TIKA_DIST_URL="https://dlcdn.apache.org/tika/3.2.2/tika-app-3.2.2.jar"
 ENV TIKA_PATH=/usr/local/bin/tika-app.jar
 
 # additional dependecies

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -45,7 +45,7 @@ RUN \
 FROM ruby:3.3-bookworm AS runner
 MAINTAINER SciNote <info@scinote.net>
 
-ARG TIKA_DIST_URL="https://dlcdn.apache.org/tika/2.9.4/tika-app-2.9.4.jar"
+ARG TIKA_DIST_URL="https://dlcdn.apache.org/tika/3.2.2/tika-app-3.2.2.jar"
 ENV TIKA_PATH=/usr/local/bin/tika-app.jar
 
 RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache


### PR DESCRIPTION
Jira ticket: [SCI-12340](https://scinote.atlassian.net/browse/SCI-12340)

### What was done
Update Tika to 3.2.2

[SCI-12340]: https://scinote.atlassian.net/browse/SCI-12340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ