### PR TITLE
Fix loading order of report templates [SCI-13479][SCI-13502]

### DIFF
--- a/app/controllers/my_module_reports_controller.rb
+++ b/app/controllers/my_module_reports_controller.rb
@@ -19,7 +19,7 @@ class MyModuleReportsController < ApplicationController
     respond_to do |format|
       format.json do
         render json: {
-          templates: @my_module.protocol.report_templates.map do |report_template|
+          templates: @my_module.protocol.report_templates.order(:created_at).map do |report_template|
             {
               id: report_template.id,
               name: report_template.name,

--- a/app/controllers/protocol_report_templates_controller.rb
+++ b/app/controllers/protocol_report_templates_controller.rb
@@ -15,7 +15,7 @@ class ProtocolReportTemplatesController < ApplicationController
     respond_to do |format|
       format.json do
         render json: {
-          templates: @protocol.report_templates.map do |report_template|
+          templates: @protocol.report_templates.order(:created_at).map do |report_template|
             {
               id: report_template.id,
               name: report_template.name,

--- a/app/javascript/vue/my_module/generate_report_wizard_steps/select_attachments_step.vue
+++ b/app/javascript/vue/my_module/generate_report_wizard_steps/select_attachments_step.vue
@@ -32,13 +32,13 @@
             <div class="text-center flex items-center gap-2 list-attachment-container w-full min-w-0">
               <i class="text-sn-grey asset-icon sn-icon sn-icon-file-pdf shrink-0"></i>
               <a
-                class="file-preview-link file-name"
+                class="file-preview-link file-name flex-[2]"
                 :id="`modal_link${element.id}`"
                 data-no-turbolink="true"
                 :data-id="element.id"
                 :data-preview-url="element.preview"
               >
-                <span class="attachment-name" data-toggle="tooltip" data-placement="bottom">
+                <span class="attachment-name truncate" data-toggle="tooltip" data-placement="bottom">
                   {{ element.file_name }}
                 </span>
               </a>


### PR DESCRIPTION
Jira ticket: [SCI-13479](https://scinote.atlassian.net/browse/SCI-13479), [SCI-13502](https://scinote.atlassian.net/browse/SCI-13502)

### What was done
Fixed the loading order of report templates and truncated the asset name in the modal

[SCI-13479]: https://scinote.atlassian.net/browse/SCI-13479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SCI-13502]: https://scinote.atlassian.net/browse/SCI-13502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ