### PR TITLE
Remove version lock for chromium package [SCI-13505]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,6 @@ MAINTAINER SciNote <info@scinote.net>
 ARG TIKA_DIST_URL="https://archive.apache.org/dist/tika/3.2.3/tika-app-3.2.3.jar"
 ENV TIKA_PATH=/usr/local/bin/tika-app.jar
 
-# Chromium 150.0.7871.46 crashes on startup under Grover/headless (https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1141571)
-ARG CHROMIUM_VERSION=149.0.7827.196-1~deb13u1
-
 # additional dependecies
 # libreoffice for file preview generation
 RUN apt-get update -qq && \
@@ -26,17 +23,10 @@ RUN apt-get update -qq && \
   fonts-wqy-microhei \
   fonts-wqy-zenhei \
   libfile-mimeinfo-perl \
+  chromium \
+  chromium-sandbox \
   npm \
   yarnpkg && \
-  echo "deb [check-valid-until=no] https://snapshot.debian.org/archive/debian-security/20260625T165532Z/ trixie-security main" > /etc/apt/sources.list.d/chromium-pin.list && \
-  apt-get update -qq && \
-  apt-get install -y --no-install-recommends \
-  chromium=$CHROMIUM_VERSION \
-  chromium-common=$CHROMIUM_VERSION \
-  chromium-sandbox=$CHROMIUM_VERSION && \
-  apt-mark hold chromium chromium-common chromium-sandbox && \
-  rm -f /etc/apt/sources.list.d/chromium-pin.list && \
-  apt-get update -qq && \
   wget -O $TIKA_PATH $TIKA_DIST_URL && \
   chmod +x $TIKA_PATH && \
   ln -s /usr/bin/yarnpkg /usr/bin/yarn && \

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -50,9 +50,6 @@ MAINTAINER SciNote <info@scinote.net>
 ARG TIKA_DIST_URL="https://archive.apache.org/dist/tika/3.2.3/tika-app-3.2.3.jar"
 ENV TIKA_PATH=/usr/local/bin/tika-app.jar
 
-# Chromium 150.0.7871.46 crashes on startup under Grover/headless (https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1141571)
-ARG CHROMIUM_VERSION=149.0.7827.196-1~deb13u1
-
 RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
 RUN \
   --mount=type=cache,target=/var/cache/apt,sharing=locked \
@@ -85,16 +82,9 @@ RUN \
   libvips42 \
   graphviz \
   libfile-mimeinfo-perl \
+  chromium \
+  chromium-sandbox \
   npm && \
-  echo "deb [check-valid-until=no] https://snapshot.debian.org/archive/debian-security/20260625T165532Z/ trixie-security main" > /etc/apt/sources.list.d/chromium-pin.list && \
-  apt-get update -qq && \
-  apt-get install -y --no-install-recommends \
-  chromium=$CHROMIUM_VERSION \
-  chromium-common=$CHROMIUM_VERSION \
-  chromium-sandbox=$CHROMIUM_VERSION && \
-  apt-mark hold chromium chromium-common chromium-sandbox && \
-  rm -f /etc/apt/sources.list.d/chromium-pin.list && \
-  apt-get update -qq && \
   wget -O $TIKA_PATH $TIKA_DIST_URL && \
   chmod +x $TIKA_PATH && \
   ln -s /usr/bin/yarnpkg /usr/bin/yarn && \


### PR DESCRIPTION
Jira ticket: [SCI-13505](https://scinote.atlassian.net/browse/SCI-13505)

### What was done
Remove version lock for chromium package

[SCI-13505]: https://scinote.atlassian.net/browse/SCI-13505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ